### PR TITLE
Exclude Gemfile.lock in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Gemfile.lock


### PR DESCRIPTION
We should exclude `Gemfile.lock` from being included in the repo. Any suggestions to add more entries to `.gitignore`?

Ref b9bede5030bd661a80f9e02327ff4fedf8570347.
