### PR TITLE
Remove mathn dependency

### DIFF
--- a/lib/classifier-reborn/extensions/vector.rb
+++ b/lib/classifier-reborn/extensions/vector.rb
@@ -4,7 +4,6 @@
 # These are extensions to the std-lib 'matrix' to allow an all ruby SVD
 
 require 'matrix'
-require 'mathn'
 
 class Array
   def sum(identity = 0, &block)

--- a/lib/classifier-reborn/lsi/content_node.rb
+++ b/lib/classifier-reborn/lsi/content_node.rb
@@ -43,8 +43,8 @@ module ClassifierReborn
         vec[word_list[word]] = @word_hash[word] if word_list[word]
       end
 
-      # Perform the scaling transform
-      total_words = vec.sum
+      # Perform the scaling transform and force floating point arithmetic
+      total_words = vec.sum.to_f
 
       total_unique_words = vec.count{|word| word != 0}
 


### PR DESCRIPTION
Remove mathn dependency. Seems that only a single area required changes after the removal of mathn to pass the tests, but we probably need to confirm this. Any ideas?
