### PR TITLE
Replace usage of monkey patches with modules

### DIFF
--- a/lib/classifier-reborn/bayes.rb
+++ b/lib/classifier-reborn/bayes.rb
@@ -23,7 +23,7 @@ module ClassifierReborn
     def train(category, text)
       category = category.prepare_category_name
                   @category_counts[category] += 1
-      text.word_hash.each do |word, count|
+      Hasher.word_hash(text).each do |word, count|
         @categories[category][word]     ||=     0
         @categories[category][word]      +=     count
         @total_words += count
@@ -40,7 +40,7 @@ module ClassifierReborn
     def untrain(category, text)
       category = category.prepare_category_name
                   @category_counts[category] -= 1
-      text.word_hash.each do |word, count|
+      Hash.word_hash(text).each do |word, count|
         if @total_words >= 0
           orig = @categories[category][word] || 0
           @categories[category][word] ||= 0
@@ -64,7 +64,7 @@ module ClassifierReborn
       @categories.each do |category, category_words|
         score[category.to_s] = 0
         total = category_words.values.inject(0) {|sum, element| sum+element}
-        text.word_hash.each do |word, count|
+        Hasher.word_hash(text).each do |word, count|
           s = category_words.has_key?(word) ? category_words[word] : 0.1
           score[category.to_s] += Math.log(s/total.to_f)
         end

--- a/lib/classifier-reborn/lsi.rb
+++ b/lib/classifier-reborn/lsi.rb
@@ -58,7 +58,7 @@ module ClassifierReborn
     #   lsi.add_item ar, *ar.categories { |x| ar.content }
     #
     def add_item( item, *categories, &block )
-      clean_word_hash = block ? block.call(item).clean_word_hash : item.to_s.clean_word_hash
+      clean_word_hash = block ? Hasher.clean_word_hash(block.call(item)) : Hasher.clean_word_hash(item.to_s)
       @items[item] = ContentNode.new(clean_word_hash, *categories)
       @version += 1
       build_index if @auto_rebuild
@@ -293,7 +293,7 @@ module ClassifierReborn
       if @items[item]
         return @items[item]
       else
-        clean_word_hash = block ? block.call(item).clean_word_hash : item.to_s.clean_word_hash
+        clean_word_hash = block ? Hasher.clean_word_hash(block.call(item)) : Hasher.clean_word_hash(item.to_s)
 
         cn = ContentNode.new(clean_word_hash, &block) # make the node and extract the data
 
@@ -308,7 +308,7 @@ module ClassifierReborn
     def make_word_list
       @word_list = WordList.new
       @items.each_value do |node|
-        node.word_hash.each_key { |key| @word_list.add_word key }
+        Hasher.word_hash(node).each_key { |key| @word_list.add_word key }
       end
     end
 

--- a/test/extensions/word_hash_test.rb
+++ b/test/extensions/word_hash_test.rb
@@ -2,13 +2,13 @@ require File.dirname(__FILE__) + '/../test_helper'
 class StringExtensionsTest < Test::Unit::TestCase
 	def test_word_hash
 		hash = {:good=>1, :"!"=>1, :hope=>1, :"'"=>1, :"."=>1, :love=>1, :word=>1, :them=>1, :test=>1}
-		assert_equal hash, "here are some good words of test's. I hope you love them!".word_hash
+		assert_equal hash, Hasher.word_hash("here are some good words of test's. I hope you love them!")
 	end
 
    	
 	def test_clean_word_hash
 	   hash = {:good=>1, :word=>1, :hope=>1, :love=>1, :them=>1, :test=>1}
-	   assert_equal hash, "here are some good words of test's. I hope you love them!".clean_word_hash
+	   assert_equal hash, Hasher.clean_word_hash("here are some good words of test's. I hope you love them!")
 	end
 
 end

--- a/test/lsi/lsi_test.rb
+++ b/test/lsi/lsi_test.rb
@@ -117,7 +117,7 @@ class LSITest < Test::Unit::TestCase
 	end
 
 	def test_summary
-	   assert_equal "This text involves dogs too [...] This text also involves cats", [@str1, @str2, @str3, @str4, @str5].join.summary(2)
+	   assert_equal "This text involves dogs too [...] This text also involves cats", Summarizer.summary([@str1, @str2, @str3, @str4, @str5].join, 2)
 	end
 
 end


### PR DESCRIPTION
Replace any usage of monkey-patched methods in Hasher and Summarizer with the module methods replacing them (see 5d4a895110dcb7e122844f4cf6f459676d505c7f).
