### PR TITLE
Add code_statistics gem as a dev dependency.

### DIFF
--- a/classifier-reborn.gemspec
+++ b/classifier-reborn.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency('rake')
   s.add_development_dependency('rdoc')
+  s.add_development_dependency('code_statistics')
 end


### PR DESCRIPTION
`$ rake stats` was failing. This fixes it by adding the missing
dependency.

Since I'm not sure whether you want it, I'm making 2 PRs. (See #17.)
- If you want to keep `rake stats`, merge this one.
- If you don't want to keep `rake stats`, close this one.
