### PR TITLE
Remove "stats" rake task.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -29,12 +29,3 @@ Rake::RDocTask.new("doc") { |rdoc|
   rdoc.rdoc_files.include('README.markdown')
   rdoc.rdoc_files.include('lib/**/*.rb')
 }
-
-desc "Report code statistics (KLOCs, etc) from the application"
-task :stats do
-  require 'code_statistics/code_statistics'
-  puts CodeStatistics::CodeStatistics.new([
-    ["Library", "lib"],
-    ["Units", "test"]
-  ]).to_s
-end


### PR DESCRIPTION
`$ rake stats` was failing. This fixes it by deleting it.

Since I'm not sure whether you want it, I'm making 2 PRs. (See #16.)
- If you want to keep `rake stats`, close this one.
- If you don't want to keep `rake stats`, merge this one.
