### PR TITLE
removed unnecessary monkey patch

### DIFF
--- a/lib/classifier-reborn/extensions/vector.rb
+++ b/lib/classifier-reborn/extensions/vector.rb
@@ -5,26 +5,6 @@
 
 require 'matrix'
 
-class Vector
-  def magnitude
-    sumsqs = 0.0
-    self.size.times do |i|
-      sumsqs += self[i] ** 2.0
-    end
-    Math.sqrt(sumsqs)
-  end
-  def normalize
-    nv = []
-    mag = self.magnitude
-    self.size.times do |i|
-
-      nv << (self[i] / mag)
-
-    end
-    Vector[*nv]
-  end
-end
-
 class Matrix
   def Matrix.diag(s)
      Matrix.diagonal(*s)


### PR DESCRIPTION
It seems like magnitude and normalize got added to the standard lib somewhere between `1.8.7` and `1.9.3`. 
