### PR TITLE
Remove references to Madeline

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -41,22 +41,21 @@ A Bayesian classifier by Lucas Carlson. Bayesian Classifiers are accurate, fast,
 
 ```ruby
 require 'classifier-reborn'
-b = ClassifierReborn::Bayes.new 'Interesting', 'Uninteresting'
-b.train_interesting "here are some good words. I hope you love them"
-b.train_uninteresting "here are some bad words, I hate you"
-b.classify "I hate bad words and you" # returns 'Uninteresting'
+classifier = ClassifierReborn::Bayes.new 'Interesting', 'Uninteresting'
+classifier.train_interesting "here are some good words. I hope you love them"
+classifier.train_uninteresting "here are some bad words, I hate you"
+classifier.classify "I hate bad words and you" # returns 'Uninteresting'
 
-require 'madeleine' # use madeline to persist the data
-m = SnapshotMadeleine.new("bayes_data") {
-  ClassifierReborn::Bayes.new 'Interesting', 'Uninteresting'
-}
-m.system.train_interesting "here are some good words. I hope you love them"
-m.system.train_uninteresting "here are some bad words, I hate you"
-m.take_snapshot
-m.system.classify "I love you" # returns 'Interesting'
+classifier_snapshot = Marshal.dump classifier
+# This is a bytestring, you can persist it anywhere you like
+Redis.current.save "classifier", classifier_snapshot
+
+# Later
+
+data = Redis.current.get "classifier"
+trained_classifier = Marshal.load data
+trained_classifier.classify "I love" # returns 'Interesting'
 ```
-
-Using Madeleine, your application can persist the learned data over time.
 
 ### Bayesian Classification
 

--- a/README.markdown
+++ b/README.markdown
@@ -47,12 +47,14 @@ classifier.train_uninteresting "here are some bad words, I hate you"
 classifier.classify "I hate bad words and you" # returns 'Uninteresting'
 
 classifier_snapshot = Marshal.dump classifier
-# This is a bytestring, you can persist it anywhere you like
-Redis.current.save "classifier", classifier_snapshot
+# This is a string of bytes, you can persist it anywhere you like
 
-# Later
+File.open("classifier.dat", "w") {|f| f.write(classifier_snapshot) }
+# Or Redis.current.save "classifier", classifier_snapshot
 
-data = Redis.current.get "classifier"
+# This is now saved to a file, and you could restart the application
+data = File.read("classifier.dat")
+# Or data = Redis.current.get "classifier"
 trained_classifier = Marshal.load data
 trained_classifier.classify "I love" # returns 'Interesting'
 ```

--- a/README.markdown
+++ b/README.markdown
@@ -52,7 +52,7 @@ classifier_snapshot = Marshal.dump classifier
 File.open("classifier.dat", "w") {|f| f.write(classifier_snapshot) }
 # Or Redis.current.save "classifier", classifier_snapshot
 
-# This is now saved to a file, and you could restart the application
+# This is now saved to a file, and you can safely restart the application
 data = File.read("classifier.dat")
 # Or data = Redis.current.get "classifier"
 trained_classifier = Marshal.load data


### PR DESCRIPTION
I feel like the example would be best using http://www.ruby-doc.org/core-2.2.0/Marshal.html not madeline.

No need to pull in extra dependencies when the standard library has got us covered, :).

Maybe using redis is a bad example and it should just write to a file?