### PR TITLE
Fix lsi.rb Comparable#== warning

### DIFF
--- a/lib/classifier-reborn/lsi.rb
+++ b/lib/classifier-reborn/lsi.rb
@@ -234,7 +234,7 @@ module ClassifierReborn
     # articles, or find paragraphs that relate to each other in an essay.
     def find_related( doc, max_nearest=3, &block )
       carry =
-        proximity_array_for_content( doc, &block ).reject { |pair| pair[0] == doc }
+        proximity_array_for_content( doc, &block ).reject { |pair| pair[0].eql? doc }
       result = carry.collect { |x| x[0] }
       return result[0..max_nearest-1]
     end


### PR DESCRIPTION
Warnings produced when doing `jekyll build` were:

warning: Comparable#== will no more rescue exceptions of #<=> in the next release.
warning: Return nil in #<=> if the comparison is inappropriate or avoid such comparison.

The warnings are supressed when using `.eql?` method.

jekyll (2.5.3)
classifier-reborn (2.0.3)
rb-gsl (1.16.0.4)