### PR TITLE
test unist is no longer in std lib, needs to be required in dev and test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
 - 1.9.3
 - 2.0
 - 2.1
+- 2.2
 notifications:
   irc:
     on_success: change

--- a/classifier-reborn.gemspec
+++ b/classifier-reborn.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency('rake')
   s.add_development_dependency('rdoc')
+  s.add_development_dependency('test-unit')
 end


### PR DESCRIPTION
Test unit has been removed from the standard lib as of 2.2.0, so it must be required to run tests.