### PR TITLE
Ruby warnings

### DIFF
--- a/lib/classifier-reborn/extensions/hasher.rb
+++ b/lib/classifier-reborn/extensions/hasher.rb
@@ -46,7 +46,7 @@ module ClassifierReborn
       hash[language] = []
 
       STOPWORDS_PATH.each do |path|
-        if File.exists?(File.join(path, language))
+        if File.exist?(File.join(path, language))
           hash[language] = Set.new File.read(File.join(path, language.to_s)).split
           break
         end

--- a/lib/classifier-reborn/extensions/vector.rb
+++ b/lib/classifier-reborn/extensions/vector.rb
@@ -21,7 +21,6 @@ class Matrix
 
     qrot    = q.dup
     v       = Matrix.identity(q.row_size)
-    azrot   = nil
     mzrot   = nil
     cnt     = 0
     s_old   = nil

--- a/lib/classifier-reborn/lsi.rb
+++ b/lib/classifier-reborn/lsi.rb
@@ -149,7 +149,7 @@ module ClassifierReborn
        return [] if needs_rebuild?
 
        avg_density = Hash.new
-       @items.each_key { |x| avg_density[x] = proximity_array_for_content(x).inject(0.0) { |x,y| x + y[1]} }
+       @items.each_key { |item| avg_density[item] = proximity_array_for_content(item).inject(0.0) { |x,y| x + y[1]} }
 
        avg_density.keys.sort_by { |x| avg_density[x] }.reverse[0..max_chunks-1].map
     end

--- a/lib/classifier-reborn/lsi.rb
+++ b/lib/classifier-reborn/lsi.rb
@@ -94,13 +94,6 @@ module ClassifierReborn
       @items.keys
     end
 
-    # Returns the categories for a given indexed items. You are free to add and remove
-    # items from this as you see fit. It does not invalide an index to change its categories.
-    def categories_for(item)
-      return [] unless @items[item]
-      return @items[item].categories
-    end
-
     # This function rebuilds the index if needs_rebuild? returns true.
     # For very large document spaces, this indexing operation may take some
     # time to complete, so it may be wise to place the operation in another

--- a/lib/classifier-reborn/lsi.rb
+++ b/lib/classifier-reborn/lsi.rb
@@ -32,7 +32,7 @@ module ClassifierReborn
     #      ClassifierReborn::LSI.new :auto_rebuild => false
     #
     def initialize(options = {})
-      @auto_rebuild = true unless options[:auto_rebuild] == false
+      @auto_rebuild = options[:auto_rebuild] != false
       @word_list, @items = WordList.new, {}
       @version, @built_at_version = 0, -1
       @language = options[:language] || 'en'

--- a/lib/classifier-reborn/lsi/content_node.rb
+++ b/lib/classifier-reborn/lsi/content_node.rb
@@ -18,6 +18,7 @@ module ClassifierReborn
     def initialize( word_hash, *categories )
       @categories = categories || []
       @word_hash = word_hash
+      @lsi_norm = nil
     end
 
     # Use this to fetch the appropriate search vector.

--- a/lib/classifier-reborn/lsi/content_node.rb
+++ b/lib/classifier-reborn/lsi/content_node.rb
@@ -18,7 +18,7 @@ module ClassifierReborn
     def initialize( word_hash, *categories )
       @categories = categories || []
       @word_hash = word_hash
-      @lsi_norm = nil
+      @lsi_norm, @lsi_vector = nil
     end
 
     # Use this to fetch the appropriate search vector.

--- a/lib/classifier-reborn/lsi/summarizer.rb
+++ b/lib/classifier-reborn/lsi/summarizer.rb
@@ -15,11 +15,11 @@ module ClassifierReborn
     end
 
     def split_sentences(str)
-      str.split /(\.|\!|\?)/ # TODO: make this less primitive
+      str.split(/(\.|\!|\?)/) # TODO: make this less primitive
     end
 
     def split_paragraphs(str)
-      str.split /(\n\n|\r\r|\r\n\r\n)/ # TODO: make this less primitive
+      str.split(/(\n\n|\r\r|\r\n\r\n)/) # TODO: make this less primitive
     end
 
     def perform_lsi(chunks, count, separator)


### PR DESCRIPTION
This eliminates several Ruby :warning:s when run with `RUBYOPT="-w"`.