### PR TITLE
Hasher performance

### DIFF
--- a/lib/classifier-reborn/extensions/hasher.rb
+++ b/lib/classifier-reborn/extensions/hasher.rb
@@ -13,9 +13,9 @@ module ClassifierReborn
     # Return a Hash of strings => ints. Each word in the string is stemmed,
     # interned, and indexes to its frequency in the document.
     def word_hash(str, language = 'en')
-      word_hash   = clean_word_hash(str, language)
-      symbol_hash = word_hash_for_symbols(str.gsub(/[\w]/," ").split)
-      return clean_word_hash(str, language).merge(symbol_hash)
+      cleaned_word_hash = clean_word_hash(str, language)
+      symbol_hash = word_hash_for_symbols(str.scan(/[^\s\p{WORD}]/))
+      return cleaned_word_hash.merge(symbol_hash)
     end
 
     # Return a word hash without extra punctuation or short symbols, just stemmed words

--- a/lib/classifier-reborn/extensions/hasher.rb
+++ b/lib/classifier-reborn/extensions/hasher.rb
@@ -2,6 +2,8 @@
 # Copyright:: Copyright (c) 2005 Lucas Carlson
 # License::   LGPL
 
+require 'set'
+
 module ClassifierReborn
   module Hasher
     STOPWORDS_PATH = [File.expand_path(File.dirname(__FILE__) + '/../../../data/stopwords')]
@@ -54,7 +56,7 @@ module ClassifierReborn
 
       STOPWORDS_PATH.each do |path|
         if File.exists?(File.join(path, language))
-          hash[language] = File.read(File.join(path, language.to_s)).split
+          hash[language] = Set.new File.read(File.join(path, language.to_s)).split
           break
         end
       end

--- a/lib/classifier-reborn/extensions/hasher.rb
+++ b/lib/classifier-reborn/extensions/hasher.rb
@@ -10,14 +10,6 @@ module ClassifierReborn
 
     extend self
 
-    # Removes common punctuation symbols, returning a new string.
-    # E.g.,
-    #   "Hello (greeting's), with {braces} < >...?".without_punctuation
-    #   => "Hello  greetings   with  braces         "
-    def without_punctuation(str)
-      str .tr( ',?.!;:"@#$%^&*()_=+[]{}\|<>/`~', " " ) .tr( "'\-", "")
-    end
-
     # Return a Hash of strings => ints. Each word in the string is stemmed,
     # interned, and indexes to its frequency in the document.
     def word_hash(str, language = 'en')

--- a/lib/classifier-reborn/extensions/hasher.rb
+++ b/lib/classifier-reborn/extensions/hasher.rb
@@ -20,14 +20,13 @@ module ClassifierReborn
 
     # Return a word hash without extra punctuation or short symbols, just stemmed words
     def clean_word_hash(str, language = 'en')
-      word_hash_for_words str.gsub(/[^\w\s]/,"").split, language
+      word_hash_for_words str.gsub(/[^\p{WORD}\s]/,'').downcase.split, language
     end
 
     def word_hash_for_words(words, language = 'en')
       d = Hash.new(0)
       words.each do |word|
-        word.downcase!
-        if ! STOPWORDS[language].include?(word) && word.length > 2
+        if word.length > 2 && !STOPWORDS[language].include?(word)
           d[word.stem.intern] += 1
         end
       end


### PR DESCRIPTION
This is a set of simple performance improvements for the Hasher process. Picking a random wikipedia page and hashing it 200 times, I get the following improvements before/after (excluding the Set regression, it was a set before my last PR). Additionally, it fixes broken regex splitting for non-ascii characters and removes the unused punctuation filter.


```
BEFORE
user     system      total        real
times:    4.400000   0.010000   4.410000 (  4.403278)

AFTER
user     system      total        real
times:    2.630000   0.010000   2.640000 (  2.632828)
```