### PR TITLE
Default hash cleanup

### DIFF
--- a/lib/classifier-reborn/bayes.rb
+++ b/lib/classifier-reborn/bayes.rb
@@ -16,12 +16,12 @@ module ClassifierReborn
         if arg.kind_of?(Hash)
           options.merge!(arg)
         else
-          @categories[CategoryNamer.prepare_name(arg)] = Hash.new
+          @categories[CategoryNamer.prepare_name(arg)] = Hash.new(0)
         end
       }
       @total_words = 0
       @category_counts = Hash.new(0)
-      @category_word_count = Hash.new
+      @category_word_count = Hash.new(0)
       @language = options[:language]
     end
 
@@ -33,11 +33,9 @@ module ClassifierReborn
     #     b.train "The other", "The other text"
     def train(category, text)
       category = CategoryNamer.prepare_name(category)
-      @categories[category] = Hash.new unless @categories.include?(category)
-      @category_word_count[category] ||= 0
+      @categories[category] = Hash.new(0) unless @categories.has_key?(category)
       @category_counts[category] += 1
       Hasher.word_hash(text, @language).each do |word, count|
-        @categories[category][word]     ||=     0
         @categories[category][word]      +=     count
         @category_word_count[category]   += count
         @total_words += count
@@ -53,12 +51,10 @@ module ClassifierReborn
     #     b.untrain :this, "This text"
     def untrain(category, text)
       category = CategoryNamer.prepare_name(category)
-      @category_word_count[category] ||= 0
       @category_counts[category] -= 1
       Hasher.word_hash(text, @language).each do |word, count|
         if @total_words >= 0
           orig = @categories[category][word] || 0
-          @categories[category][word]     ||=     0
           @categories[category][word]      -=     count
           if @categories[category][word] <= 0
             @categories[category].delete(word)
@@ -144,7 +140,7 @@ module ClassifierReborn
     # more criteria than the trained selective categories. In short,
     # try to initialize your categories at initialization.
     def add_category(category)
-      @categories[CategoryNamer.prepare_name(category)] = Hash.new
+      @categories[CategoryNamer.prepare_name(category)] = Hash.new(0)
     end
 
     alias append_category add_category

--- a/lib/classifier-reborn/bayes.rb
+++ b/lib/classifier-reborn/bayes.rb
@@ -6,7 +6,7 @@ require_relative 'category_namer'
 
 module ClassifierReborn
   class Bayes
-    class CategoryNotFound < StandardError; end
+    class CategoryNotFoundError < StandardError; end
 
     # The class can be created with one or more categories, each of which will be
     # initialized and given a training method. E.g.,
@@ -42,7 +42,7 @@ module ClassifierReborn
         if @auto_categorize
           add_category(category)
         else
-          raise CategoryNotFound.new("Cannot train; category #{category} does not exist")
+          raise CategoryNotFoundError.new("Cannot train; category #{category} does not exist")
         end
       end
 

--- a/lib/classifier-reborn/bayes.rb
+++ b/lib/classifier-reborn/bayes.rb
@@ -6,7 +6,7 @@ require_relative 'category_namer'
 
 module ClassifierReborn
   class Bayes
-    class CategoryNotFoundError < StandardError; end
+    CategoryNotFoundError = Class.new(StandardError)
 
     # The class can be created with one or more categories, each of which will be
     # initialized and given a training method. E.g.,

--- a/lib/classifier-reborn/bayes.rb
+++ b/lib/classifier-reborn/bayes.rb
@@ -140,7 +140,7 @@ module ClassifierReborn
     # more criteria than the trained selective categories. In short,
     # try to initialize your categories at initialization.
     def add_category(category)
-      @categories[CategoryNamer.prepare_name(category)] = Hash.new(0)
+      @categories[CategoryNamer.prepare_name(category)] ||= Hash.new(0)
     end
 
     alias append_category add_category

--- a/lib/classifier-reborn/category_namer.rb
+++ b/lib/classifier-reborn/category_namer.rb
@@ -9,7 +9,9 @@ module ClassifierReborn
   module CategoryNamer
     extend self
     def prepare_name(name) 
-      name.to_s.gsub("_"," ").capitalize.intern 
+      return name if name.is_a?(Symbol)
+
+      name.to_s.gsub("_"," ").capitalize.intern
     end
   end
 end

--- a/test/bayes/bayesian_test.rb
+++ b/test/bayes/bayesian_test.rb
@@ -37,7 +37,7 @@ class BayesianTest < Test::Unit::TestCase
 	end
 
 	def test_dynamic_category_fails_without_auto_categorize
-		assert_raises(ClassifierReborn::Bayes::CategoryNotFound) {
+		assert_raises(ClassifierReborn::Bayes::CategoryNotFoundError) {
 		  @classifier.train('Ruby', 'I really sweet language')
 		}
 		refute @classifier.categories.include?('Ruby')

--- a/test/bayes/bayesian_test.rb
+++ b/test/bayes/bayesian_test.rb
@@ -30,9 +30,17 @@ class BayesianTest < Test::Unit::TestCase
 		assert_equal ['Test', 'Interesting', 'Uninteresting'].sort, @classifier.categories.sort
 	end
 	
-	def test_dynamic_category_thru_training
-		@classifier.train('Ruby', 'I really sweet language')
-		assert @classifier.categories.include?('Ruby')
+	def test_dynamic_category_succeeds_with_auto_categorize
+		classifier = ClassifierReborn::Bayes.new 'Interesting', 'Uninteresting', auto_categorize: true
+		classifier.train('Ruby', 'I really sweet language')
+		assert classifier.categories.include?('Ruby')
+	end
+
+	def test_dynamic_category_fails_without_auto_categorize
+		assert_raises(ClassifierReborn::Bayes::CategoryNotFound) {
+		  @classifier.train('Ruby', 'I really sweet language')
+		}
+		refute @classifier.categories.include?('Ruby')
 	end
 
 	def test_classification

--- a/test/bayes/bayesian_test.rb
+++ b/test/bayes/bayesian_test.rb
@@ -20,7 +20,7 @@ class BayesianTest < Test::Unit::TestCase
 		assert_equal ['Interesting', 'Uninteresting'].sort, @classifier.categories.sort
 	end
 	
-	def test_categproes_from_array
+	def test_categories_from_array
 		another_classifier = ClassifierReborn::Bayes.new ['Interesting', 'Uninteresting']
 		assert_equal another_classifier.categories.sort, @classifier.categories.sort
 	end


### PR DESCRIPTION
Few things got done here:
* Set up a few things to use default hash values
* made auto-categorization optional, defaulting to false
* Fixed the bug where adding the same category a second time would completely clobber the category that was already there
* If a category name is already a symbol, just return it