### PR TITLE
Option to Disable Stemming

### DIFF
--- a/lib/classifier-reborn/bayes.rb
+++ b/lib/classifier-reborn/bayes.rb
@@ -158,6 +158,16 @@ module ClassifierReborn
       !@enable_threshold
     end
 
+    # Is word stemming enabled?
+    def stemmer_enabled?
+      @enable_stemmer
+    end
+
+    # Is word stemming disabled?
+    def stemmer_disabled?
+      !@enable_stemmer
+    end
+
     # Provides training and untraining methods for the categories specified in Bayes#new
     # For example:
     #     b = ClassifierReborn::Bayes.new 'This', 'That', 'the_other'

--- a/lib/classifier-reborn/extensions/hasher.rb
+++ b/lib/classifier-reborn/extensions/hasher.rb
@@ -13,21 +13,26 @@ module ClassifierReborn
 
     # Return a Hash of strings => ints. Each word in the string is stemmed,
     # interned, and indexes to its frequency in the document.
-    def word_hash(str, language = 'en')
-      cleaned_word_hash = clean_word_hash(str, language)
+    def word_hash(str, language = 'en', enable_stemmer = true)
+      cleaned_word_hash = clean_word_hash(str, language, enable_stemmer)
       symbol_hash = word_hash_for_symbols(str.scan(/[^\s\p{WORD}]/))
       cleaned_word_hash.merge(symbol_hash)
     end
 
     # Return a word hash without extra punctuation or short symbols, just stemmed words
-    def clean_word_hash(str, language = 'en')
-      word_hash_for_words str.gsub(/[^\p{WORD}\s]/, '').downcase.split, language
+    def clean_word_hash(str, language = 'en', enable_stemmer = true)
+      word_hash_for_words str.gsub(/[^\p{WORD}\s]/, '').downcase.split, language, enable_stemmer
     end
 
-    def word_hash_for_words(words, language = 'en')
+    def word_hash_for_words(words, language = 'en', enable_stemmer = true)
       d = Hash.new(0)
       words.each do |word|
-        d[word.stem.intern] += 1 if word.length > 2 && !STOPWORDS[language].include?(word)
+        next unless word.length > 2 && !STOPWORDS[language].include?(word)
+        if enable_stemmer
+          d[word.stem.intern] += 1
+        else
+          d[word.intern] += 1
+        end
       end
       d
     end

--- a/test/bayes/bayesian_test.rb
+++ b/test/bayes/bayesian_test.rb
@@ -14,6 +14,10 @@ class BayesianTest < Test::Unit::TestCase
     assert_nothing_raised { @classifier.train_interesting 'Água' }
   end
 
+  def test_stemming_enabled_by_default
+    assert @classifier.stemmer_enabled?
+  end
+
   def test_bad_training
     assert_raise(StandardError) { @classifier.train_no_category 'words' }
   end

--- a/test/extensions/hasher_test.rb
+++ b/test/extensions/hasher_test.rb
@@ -15,6 +15,11 @@ class HasherTest < Test::Unit::TestCase
     assert_equal hash, Hasher.clean_word_hash("here are some good words of test's. I hope you love them!")
   end
 
+  def test_clean_word_hash_without_stemming
+    hash = { good: 1, words: 1, hope: 1, love: 1, them: 1, tests: 1 }
+    assert_equal hash, Hasher.clean_word_hash("here are some good words of test's. I hope you love them!", 'en', false)
+  end
+
   def test_default_stopwords
     assert_not_empty Hasher::STOPWORDS['en']
     assert_not_empty Hasher::STOPWORDS['fr']


### PR DESCRIPTION
Adds an option to the bayesian classifier to disable word stemming. This is necessary for use cases where two words that are stemmed to the same root should actually be classified differently.