### PR TITLE
Method to add custom path to user-created stopword directory

### DIFF
--- a/lib/classifier-reborn/extensions/hasher.rb
+++ b/lib/classifier-reborn/extensions/hasher.rb
@@ -37,6 +37,11 @@ module ClassifierReborn
       d
     end
 
+    # Add custom path to a new stopword file created by user
+    def add_custom_stopword_path(path)
+      STOPWORDS_PATH.unshift(path)
+    end
+
     def word_hash_for_symbols(words)
       d = Hash.new(0)
       words.each do |word|

--- a/test/extensions/hasher_test.rb
+++ b/test/extensions/hasher_test.rb
@@ -1,4 +1,5 @@
-require File.dirname(__FILE__) + '/../test_helper'
+require_relative '../test_helper'
+require 'tempfile'
 
 class HasherTest < Test::Unit::TestCase
   def setup
@@ -38,6 +39,25 @@ class HasherTest < Test::Unit::TestCase
     custom_english_stopwords = Hasher::STOPWORDS['en']
 
     assert_not_equal default_english_stopwords, custom_english_stopwords
+  end
+
+  def test_add_custom_stopword_path
+    # Create stopword tempfile in current directory
+    temp_stopwords = Tempfile.new('xy', "#{File.dirname(__FILE__) + "/"}")
+    
+    # Add some stopwords to tempfile
+    temp_stopwords << "this words fun"
+    temp_stopwords.close 
+    
+    # Get path of tempfile
+    temp_stopwords_path = File.dirname(temp_stopwords)
+
+    # Get tempfile name.
+    temp_stopwords_name = File.basename(temp_stopwords.path)
+
+    Hasher.add_custom_stopword_path(temp_stopwords_path)
+    hash = { list: 1, cool: 1 }
+    assert_equal hash, Hasher.clean_word_hash("this is a list of cool words!", temp_stopwords_name)
   end
 
   def teardown


### PR DESCRIPTION
Per discussion in [Functionality to modify stopword lists?](https://github.com/jekyll/classifier-reborn/issues/72) thread. I added a method to hasher module so users can add a custom path to a directory with user-made stopword files.

```
def add_custom_stopword_path(path)
  STOPWORDS_PATH.unshift(path)
end
```

Not sure it adds a tonne of value over the current way to hack it,
**Current:**
```
include ClassifierReborn
Hasher::STOPWORDS_PATH.unshift("/home/ubuntu/workspace/data")
```

But I think it makes adding a path slightly more intuitive for someone not digging into the code.
**Updated:**
```
include ClassifierReborn
Hasher.add_custom_stopword_path("/home/ubuntu/workspace/data")
```

Thoughts?