### PR TITLE
Fix searching issues with classifier-reborn

### DIFF
--- a/lib/classifier-reborn/lsi.rb
+++ b/lib/classifier-reborn/lsi.rb
@@ -200,6 +200,11 @@ module ClassifierReborn
       return [] if needs_rebuild?
 
       content_node = node_for_content(doc, &block)
+
+      if $GSL && content_node.raw_norm.isnan?.all?
+        raise "There are no documents that are similar to #{doc}"
+      end
+
       result =
         @items.keys.collect do |item|
           if $GSL

--- a/lib/classifier-reborn/lsi.rb
+++ b/lib/classifier-reborn/lsi.rb
@@ -17,6 +17,7 @@ require_relative 'lsi/word_list'
 require_relative 'lsi/content_node'
 require_relative 'lsi/cached_content_node'
 require_relative 'lsi/summarizer'
+require 'pry'
 
 module ClassifierReborn
   # This class implements a Latent Semantic Indexer, which can search, classify and cluster
@@ -64,6 +65,9 @@ module ClassifierReborn
     #
     def add_item(item, *categories, &block)
       clean_word_hash = Hasher.clean_word_hash((block ? block.call(item) : item.to_s), @language)
+      if clean_word_hash.empty?
+        raise "#{item} is composed entirely of stopwords and words that are 2 characters or less. Classifier-Reborn cannot handle this document properly, and thus summarily rejected it."
+      end
       @items[item] = if @cache_node_vectors
                        CachedContentNode.new(clean_word_hash, *categories)
                      else

--- a/lib/classifier-reborn/lsi.rb
+++ b/lib/classifier-reborn/lsi.rb
@@ -17,7 +17,6 @@ require_relative 'lsi/word_list'
 require_relative 'lsi/content_node'
 require_relative 'lsi/cached_content_node'
 require_relative 'lsi/summarizer'
-require 'pry'
 
 module ClassifierReborn
   # This class implements a Latent Semantic Indexer, which can search, classify and cluster

--- a/test/lsi/lsi_test.rb
+++ b/test/lsi/lsi_test.rb
@@ -181,6 +181,19 @@ class LSITest < Test::Unit::TestCase
     assert_equal [:dog, :text, :deal], lsi.highest_ranked_stems(@str1)
   end
 
+  def test_invalid_searching_when_using_gsl
+    return unless $GSL
+    lsi = ClassifierReborn::LSI.new
+    lsi.add_item @str1, 'Dog'
+    lsi.add_item @str2, 'Dog'
+    lsi.add_item @str3, 'Cat'
+    lsi.add_item @str4, 'Cat'
+    lsi.add_item @str5, 'Bird'
+    assert_raises RuntimeError do
+      lsi.search('penguin')
+    end
+  end
+
   def test_summary
     assert_equal 'This text involves dogs too [...] This text also involves cats', Summarizer.summary([@str1, @str2, @str3, @str4, @str5].join, 2)
   end

--- a/test/lsi/lsi_test.rb
+++ b/test/lsi/lsi_test.rb
@@ -194,6 +194,13 @@ class LSITest < Test::Unit::TestCase
     end
   end
 
+  def test_raise_error_when_adding_bad_document
+    lsi = ClassifierReborn::LSI.new
+    assert_raises RuntimeError do
+      lsi.add_item("i can")
+    end
+  end
+
   def test_summary
     assert_equal 'This text involves dogs too [...] This text also involves cats', Summarizer.summary([@str1, @str2, @str3, @str4, @str5].join, 2)
   end


### PR DESCRIPTION
This pull request should handle issues #64 and #75, mostly by throwing up human-readable error messages. Error messages aren't cool, but they're more graceful than programs crashing.

Issue #64 is caused by adding "invalid" documents beforehand, and we resolve this by rejecting those "invalid" documents before they could cause problems later on for the end-user. If you try to search a corpus of documents that include "invalid" documents, the program will crash. If you try to find related phrases, it _won't_ crash and you'll still get results. However, I would still recommend rejecting "invalid" documents outright because these invalid documents adds noise that can narrowly impact the LSI's results.

Issue #75 is caused by attempting to search through a corpus for a term that does not exist within the corpus. We resolve this issue by rejecting the search term outright. The user here knows that no document has the search term in question, and will be able to move on with their lives. This bug fix only works if you have GSL...otherwise, you just get the built-in "Cannot Normalize Zero Vector" error (which isn't a user-friendly error message, but it does stop invalid searches).

Let me know if these changes are appropriate or if you have your own suggestions.
