### PR TITLE
Memory and Redis backend support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,5 @@ notifications:
     on_failure: change
 sudo: false
 cache: bundler
+services:
+  - redis-server

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,4 @@
 source 'https://rubygems.org'
 gemspec
+
+gem 'redis'

--- a/README.markdown
+++ b/README.markdown
@@ -62,7 +62,7 @@ trained_classifier.classify "I love" # returns 'Interesting'
 ```
 
 Beyond the basic example, the constructor and trainer can be used in a more
-flexible way to accomidate non-trival applications.  Consider the following
+flexible way to accommodate non-trival applications.  Consider the following
 program:
 
 ```ruby

--- a/lib/classifier-reborn/backends/bayes_memory_backend.rb
+++ b/lib/classifier-reborn/backends/bayes_memory_backend.rb
@@ -26,7 +26,7 @@ module ClassifierReborn
     end
 
     def category_has_trainings?(category)
-      @category_counts.key?(category) && @category_counts[category][:training] > 0
+      @category_counts.key?(category) && category_training_count(category) > 0
     end
 
     def category_word_count(category)

--- a/lib/classifier-reborn/backends/bayes_memory_backend.rb
+++ b/lib/classifier-reborn/backends/bayes_memory_backend.rb
@@ -1,0 +1,72 @@
+# Author: Sawood Alam <@ibnesayeed>
+
+module ClassifierReborn
+  class BayesMemoryBackend
+    def initialize
+      @total_words     = 0
+      @total_trainings = 0
+      @category_counts = Hash.new { |h, k| h[k] = {training: 0, word: 0} }
+      @categories      = {}
+    end
+
+    def total_words
+      @total_words
+    end
+
+    def update_total_words(diff)
+      @total_words += diff
+    end
+
+    def total_trainings
+      @total_trainings
+    end
+
+    def update_total_trainings(diff)
+      @total_trainings += diff
+    end
+
+    def category_training_count(category)
+      @category_counts[category][:training]
+    end
+
+    def update_category_training_count(category, diff)
+      @category_counts[category][:training] += diff
+    end
+
+    def category_has_trainings?(category)
+      @category_counts.key?(category) && @category_counts[category][:training] > 0
+    end
+
+    def category_word_count(category)
+      @category_counts[category][:word]
+    end
+
+    def update_category_word_count(category, diff)
+      @category_counts[category][:word] += diff
+    end
+
+    def add_category(category)
+      @categories[category] ||= Hash.new(0)
+    end
+
+    def category_keys
+      @categories.keys
+    end
+
+    def category_word_frequency(category, word)
+      @categories[category][word]
+    end
+
+    def update_category_word_frequency(category, word, diff)
+      @categories[category][word] += diff
+    end
+
+    def delete_category_word(category, word)
+      @categories[category].delete(word)
+    end
+
+    def word_in_category?(category, word)
+      @categories[category].key?(word)
+    end
+  end
+end

--- a/lib/classifier-reborn/backends/bayes_memory_backend.rb
+++ b/lib/classifier-reborn/backends/bayes_memory_backend.rb
@@ -1,7 +1,7 @@
-# Author: Sawood Alam <@ibnesayeed>
-
 module ClassifierReborn
   class BayesMemoryBackend
+    attr_reader :total_words, :total_trainings
+
     def initialize
       @total_words     = 0
       @total_trainings = 0
@@ -9,16 +9,8 @@ module ClassifierReborn
       @categories      = {}
     end
 
-    def total_words
-      @total_words
-    end
-
     def update_total_words(diff)
       @total_words += diff
-    end
-
-    def total_trainings
-      @total_trainings
     end
 
     def update_total_trainings(diff)

--- a/lib/classifier-reborn/backends/bayes_redis_backend.rb
+++ b/lib/classifier-reborn/backends/bayes_redis_backend.rb
@@ -1,0 +1,69 @@
+# Author: Sawood Alam <@ibnesayeed>
+
+module ClassifierReborn
+  class BayesRedisBackend
+    def initialize(redis_con_str)
+      # TODO: Initialize Redis connection and necessary data structures
+    end
+
+    def total_words
+      # TODO: Yet to implement
+    end
+
+    def update_total_words(diff)
+      # TODO: Yet to implement
+    end
+
+    def total_trainings
+      # TODO: Yet to implement
+    end
+
+    def update_total_trainings(diff)
+      # TODO: Yet to implement
+    end
+
+    def category_training_count(category)
+      # TODO: Yet to implement
+    end
+
+    def update_category_training_count(category, diff)
+      # TODO: Yet to implement
+    end
+
+    def category_has_trainings?(category)
+      # TODO: Yet to implement
+    end
+
+    def category_word_count(category)
+      # TODO: Yet to implement
+    end
+
+    def update_category_word_count(category, diff)
+      # TODO: Yet to implement
+    end
+
+    def add_category(category)
+      # TODO: Yet to implement
+    end
+
+    def category_keys
+      # TODO: Yet to implement
+    end
+
+    def category_word_frequency(category, word)
+      # TODO: Yet to implement
+    end
+
+    def update_category_word_frequency(category, word, diff)
+      # TODO: Yet to implement
+    end
+
+    def delete_category_word(category, word)
+      # TODO: Yet to implement
+    end
+
+    def word_in_category?(category, word)
+      # TODO: Yet to implement
+    end
+  end
+end

--- a/lib/classifier-reborn/backends/bayes_redis_backend.rb
+++ b/lib/classifier-reborn/backends/bayes_redis_backend.rb
@@ -1,67 +1,71 @@
+require 'redis'
+
 module ClassifierReborn
   class BayesRedisBackend
-    def initialize(redis_con_str)
-      # TODO: Initialize Redis connection and necessary data structures
+    def initialize(options = {})
+      @redis = Redis.new(options)
+      @redis.set(:total_words, 0)
+      @redis.set(:total_trainings, 0)
     end
 
     def total_words
-      # TODO: Yet to implement
+      @redis.get(:total_words).to_i
     end
 
     def update_total_words(diff)
-      # TODO: Yet to implement
+      @redis.incrby(:total_words, diff)
     end
 
     def total_trainings
-      # TODO: Yet to implement
+      @redis.get(:total_trainings).to_i
     end
 
     def update_total_trainings(diff)
-      # TODO: Yet to implement
+      @redis.incrby(:total_trainings, diff)
     end
 
     def category_training_count(category)
-      # TODO: Yet to implement
+      @redis.hget(:category_training_count, category).to_i
     end
 
     def update_category_training_count(category, diff)
-      # TODO: Yet to implement
+      @redis.hincrby(:category_training_count, category, diff)
     end
 
     def category_has_trainings?(category)
-      # TODO: Yet to implement
+      category_training_count(category) > 0
     end
 
     def category_word_count(category)
-      # TODO: Yet to implement
+      @redis.hget(:category_word_count, category).to_i
     end
 
     def update_category_word_count(category, diff)
-      # TODO: Yet to implement
+      @redis.hincrby(:category_word_count, category, diff)
     end
 
     def add_category(category)
-      # TODO: Yet to implement
+      @redis.sadd(:category_keys, category)
     end
 
     def category_keys
-      # TODO: Yet to implement
+      @redis.smembers(:category_keys).map(&:intern)
     end
 
     def category_word_frequency(category, word)
-      # TODO: Yet to implement
+      @redis.hget(category, word).to_i
     end
 
     def update_category_word_frequency(category, word, diff)
-      # TODO: Yet to implement
+      @redis.hincrby(category, word, diff)
     end
 
     def delete_category_word(category, word)
-      # TODO: Yet to implement
+      @redis.hdel(category, word)
     end
 
     def word_in_category?(category, word)
-      # TODO: Yet to implement
+      @redis.hexists(category, word)
     end
   end
 end

--- a/lib/classifier-reborn/backends/bayes_redis_backend.rb
+++ b/lib/classifier-reborn/backends/bayes_redis_backend.rb
@@ -1,5 +1,3 @@
-# Author: Sawood Alam <@ibnesayeed>
-
 module ClassifierReborn
   class BayesRedisBackend
     def initialize(redis_con_str)

--- a/lib/classifier-reborn/bayes.rb
+++ b/lib/classifier-reborn/bayes.rb
@@ -3,6 +3,8 @@
 # License::   LGPL
 
 require_relative 'category_namer'
+require_relative 'backends/bayes_memory_backend'
+require_relative 'backends/bayes_redis_backend'
 
 module ClassifierReborn
   class Bayes
@@ -19,24 +21,27 @@ module ClassifierReborn
     #   threshold:        0.0    Default threshold, only used when enabled
     #   enable_stemmer:   true   When false, disables word stemming
     def initialize(*args)
-      @categories = {}
+      initial_categories = []
       options = { language:         'en',
                   auto_categorize:  false,
                   enable_threshold: false,
                   threshold:        0.0,
-                  enable_stemmer:   true
+                  enable_stemmer:   true,
+                  redis_con_str:    ''
                 }
       args.flatten.each do |arg|
         if arg.is_a?(Hash)
           options.merge!(arg)
         else
-          add_category(arg)
+          initial_categories.push(arg)
         end
       end
 
-      @total_words         = 0
-      @category_counts     = Hash.new(0)
-      @category_word_count = Hash.new(0)
+      @backend = options[:redis_con_str].empty? ? BayesMemoryBackend.new : BayesRedisBackend.new(options[:redis_con_str])
+
+      initial_categories.each do |c|
+        add_category(c)
+      end
 
       @language            = options[:language]
       @auto_categorize     = options[:auto_categorize]
@@ -55,7 +60,7 @@ module ClassifierReborn
       category = CategoryNamer.prepare_name(category)
 
       # Add the category dynamically or raise an error
-      unless @categories.key?(category)
+      unless category_keys.include?(category)
         if @auto_categorize
           add_category(category)
         else
@@ -63,11 +68,12 @@ module ClassifierReborn
         end
       end
 
-      @category_counts[category] += 1
+      @backend.update_category_training_count(category, 1)
+      @backend.update_total_trainings(1)
       Hasher.word_hash(text, @language, @enable_stemmer).each do |word, count|
-        @categories[category][word] += count
-        @category_word_count[category] += count
-        @total_words += count
+        @backend.update_category_word_frequency(category, word, count)
+        @backend.update_category_word_count(category, count)
+        @backend.update_total_words(count)
       end
     end
 
@@ -80,18 +86,19 @@ module ClassifierReborn
     #     b.untrain :this, "This text"
     def untrain(category, text)
       category = CategoryNamer.prepare_name(category)
-      @category_counts[category] -= 1
+      @backend.update_category_training_count(category, -1)
+      @backend.update_total_trainings(-1)
       Hasher.word_hash(text, @language, @enable_stemmer).each do |word, count|
-        next if @total_words < 0
-        orig = @categories[category][word] || 0
-        @categories[category][word] -= count
-        if @categories[category][word] <= 0
-          @categories[category].delete(word)
+        next if @backend.total_words < 0
+        orig = @backend.category_word_frequency(category, word) || 0
+        @backend.update_category_word_frequency(category, word, -count)
+        if @backend.category_word_frequency(category, word) <= 0
+          @backend.delete_category_word(category, word)
           count = orig
         end
 
-        @category_word_count[category] -= count if @category_word_count[category] >= count
-        @total_words -= count
+        @backend.update_category_word_count(category, -count) if @backend.category_word_count(category) >= count
+        @backend.update_total_words(-count)
       end
     end
 
@@ -102,17 +109,16 @@ module ClassifierReborn
     def classifications(text)
       score = {}
       word_hash = Hasher.word_hash(text, @language, @enable_stemmer)
-      training_count = @category_counts.values.reduce(:+).to_f
-      @categories.each do |category, category_words|
+      category_keys.each do |category|
         score[category.to_s] = 0
-        total = (@category_word_count[category] || 1).to_f
+        total = (@backend.category_word_count(category) || 1).to_f
         word_hash.each do |word, _count|
-          s = category_words.key?(word) ? category_words[word] : 0.1
+          s = @backend.word_in_category?(category, word) ? @backend.category_word_frequency(category, word) : 0.1
           score[category.to_s] += Math.log(s / total)
         end
         # now add prior probability for the category
-        s = @category_counts.key?(category) ? @category_counts[category] : 0.1
-        score[category.to_s] += Math.log(s / training_count)
+        s = @backend.category_has_trainings?(category) ? @backend.category_training_count(category) : 0.1
+        score[category.to_s] += Math.log(s / @backend.total_trainings.to_f)
       end
       score
     end
@@ -178,7 +184,7 @@ module ClassifierReborn
     def method_missing(name, *args)
       cleaned_name = name.to_s.gsub(/(un)?train_([\w]+)/, '\2')
       category = CategoryNamer.prepare_name(cleaned_name)
-      if @categories.key? category
+      if category_keys.include?(category)
         args.each { |text| eval("#{Regexp.last_match(1)}train(category, text)") }
       elsif name.to_s =~ /(un)?train_([\w]+)/
         raise StandardError, "No such category: #{category}"
@@ -192,7 +198,11 @@ module ClassifierReborn
     #     b.categories
     #     =>   ['This', 'That', 'the_other']
     def categories # :nodoc:
-      @categories.keys.collect(&:to_s)
+      category_keys.collect(&:to_s)
+    end
+
+    def category_keys
+      @backend.category_keys
     end
 
     # Allows you to add categories to the classifier.
@@ -204,7 +214,8 @@ module ClassifierReborn
     # more criteria than the trained selective categories. In short,
     # try to initialize your categories at initialization.
     def add_category(category)
-      @categories[CategoryNamer.prepare_name(category)] ||= Hash.new(0)
+      category = CategoryNamer.prepare_name(category)
+      @backend.add_category(category)
     end
 
     alias_method :append_category, :add_category

--- a/lib/classifier-reborn/bayes.rb
+++ b/lib/classifier-reborn/bayes.rb
@@ -27,7 +27,7 @@ module ClassifierReborn
                   enable_threshold: false,
                   threshold:        0.0,
                   enable_stemmer:   true,
-                  redis_con_str:    ''
+                  backend:          BayesMemoryBackend.new
                 }
       args.flatten.each do |arg|
         if arg.is_a?(Hash)
@@ -37,17 +37,16 @@ module ClassifierReborn
         end
       end
 
-      @backend = options[:redis_con_str].empty? ? BayesMemoryBackend.new : BayesRedisBackend.new(options[:redis_con_str])
-
-      initial_categories.each do |c|
-        add_category(c)
-      end
-
       @language            = options[:language]
       @auto_categorize     = options[:auto_categorize]
       @enable_threshold    = options[:enable_threshold]
       @threshold           = options[:threshold]
       @enable_stemmer      = options[:enable_stemmer]
+      @backend             = options[:backend]
+
+      initial_categories.each do |c|
+        add_category(c)
+      end
     end
 
     # Provides a general training method for all categories specified in Bayes#new

--- a/test/backends/backend_common_tests.rb
+++ b/test/backends/backend_common_tests.rb
@@ -1,0 +1,58 @@
+# encoding: utf-8
+
+module BackendCommonTests
+  def test_initial_values
+    assert_equal 0, @backend.total_words
+    assert_equal 0, @backend.total_trainings
+    assert_equal [], @backend.category_keys
+  end
+
+  def test_total_words
+    @backend.update_total_words(10)
+    assert_equal 10, @backend.total_words
+    @backend.update_total_words(-7)
+    assert_equal 3, @backend.total_words
+  end
+
+  def test_total_trainings
+    @backend.update_total_trainings(10)
+    assert_equal 10, @backend.total_trainings
+    @backend.update_total_trainings(-7)
+    assert_equal 3, @backend.total_trainings
+  end
+
+  def test_category_training
+    assert !@backend.category_has_trainings?(:Interesting)
+    @backend.update_category_training_count(:Interesting, 10)
+    assert @backend.category_has_trainings?(:Interesting)
+    assert_equal 10, @backend.category_training_count(:Interesting)
+    @backend.update_category_training_count(:Interesting, -7)
+    assert_equal 3, @backend.category_training_count(:Interesting)
+  end
+
+  def test_category_word
+    @backend.update_category_word_count(:Interesting, 10)
+    assert_equal 10, @backend.category_word_count(:Interesting)
+    @backend.update_category_word_count(:Interesting, -7)
+    assert_equal 3, @backend.category_word_count(:Interesting)
+  end
+
+  def test_category
+    @backend.add_category(:Interesting)
+    @backend.add_category(:"Not so interesting")
+    assert_equal [:Interesting, :"Not so interesting"].sort, @backend.category_keys.sort
+  end
+
+  def test_category_word_frequency
+    @backend.add_category(:Interesting)
+    assert !@backend.word_in_category?(:Interesting, "foo")
+    assert_equal 0, @backend.category_word_frequency(:Interesting, "foo")
+    @backend.update_category_word_frequency(:Interesting, "foo", 10)
+    assert @backend.word_in_category?(:Interesting, "foo")
+    assert_equal 10, @backend.category_word_frequency(:Interesting, "foo")
+    @backend.update_category_word_frequency(:Interesting, "foo", -7)
+    assert_equal 3, @backend.category_word_frequency(:Interesting, "foo")
+    @backend.delete_category_word(:Interesting, "foo")
+    assert !@backend.word_in_category?(:Interesting, "foo")
+  end
+end

--- a/test/backends/backend_common_tests.rb
+++ b/test/backends/backend_common_tests.rb
@@ -22,7 +22,7 @@ module BackendCommonTests
   end
 
   def test_category_training
-    assert !@backend.category_has_trainings?(:Interesting)
+    refute @backend.category_has_trainings?(:Interesting)
     @backend.update_category_training_count(:Interesting, 10)
     assert @backend.category_has_trainings?(:Interesting)
     assert_equal 10, @backend.category_training_count(:Interesting)
@@ -45,7 +45,7 @@ module BackendCommonTests
 
   def test_category_word_frequency
     @backend.add_category(:Interesting)
-    assert !@backend.word_in_category?(:Interesting, "foo")
+    refute @backend.word_in_category?(:Interesting, "foo")
     assert_equal 0, @backend.category_word_frequency(:Interesting, "foo")
     @backend.update_category_word_frequency(:Interesting, "foo", 10)
     assert @backend.word_in_category?(:Interesting, "foo")
@@ -53,6 +53,6 @@ module BackendCommonTests
     @backend.update_category_word_frequency(:Interesting, "foo", -7)
     assert_equal 3, @backend.category_word_frequency(:Interesting, "foo")
     @backend.delete_category_word(:Interesting, "foo")
-    assert !@backend.word_in_category?(:Interesting, "foo")
+    refute @backend.word_in_category?(:Interesting, "foo")
   end
 end

--- a/test/backends/backend_memory_test.rb
+++ b/test/backends/backend_memory_test.rb
@@ -1,0 +1,12 @@
+# encoding: utf-8
+
+require File.dirname(__FILE__) + '/../test_helper'
+require_relative './backend_common_tests'
+
+class BackendMemoryTest < Test::Unit::TestCase
+  include BackendCommonTests
+
+  def setup
+    @backend = ClassifierReborn::BayesMemoryBackend.new
+  end
+end

--- a/test/backends/backend_redis_test.rb
+++ b/test/backends/backend_redis_test.rb
@@ -1,0 +1,20 @@
+# encoding: utf-8
+
+require File.dirname(__FILE__) + '/../test_helper'
+require_relative './backend_common_tests'
+
+class BackendRedisTest < Test::Unit::TestCase
+  include BackendCommonTests
+
+  def setup
+    begin
+      @backend = ClassifierReborn::BayesRedisBackend.new
+    rescue Redis::CannotConnectError => e
+      omit(e)
+    end
+  end
+
+  def cleanup
+    @backend.instance_variable_get(:@redis).flushdb
+  end
+end

--- a/test/backends/backend_redis_test.rb
+++ b/test/backends/backend_redis_test.rb
@@ -10,7 +10,7 @@ class BackendRedisTest < Minitest::Test
     begin
       @backend = ClassifierReborn::BayesRedisBackend.new
     rescue Redis::CannotConnectError => e
-      omit(e)
+      skip(e)
     end
   end
 

--- a/test/bayes/bayesian_common_tests.rb
+++ b/test/bayes/bayesian_common_tests.rb
@@ -26,7 +26,6 @@ module BayesianCommonTests
   end
 
   def test_categories_from_array
-    another_classifier = ClassifierReborn::Bayes.new %w(Interesting Uninteresting)
     assert_equal another_classifier.categories.sort, @classifier.categories.sort
   end
 
@@ -36,7 +35,7 @@ module BayesianCommonTests
   end
 
   def test_dynamic_category_succeeds_with_auto_categorize
-    classifier = ClassifierReborn::Bayes.new 'Interesting', 'Uninteresting', auto_categorize: true
+    classifier = auto_categorize_classifier
     classifier.train('Ruby', 'I really sweet language')
     assert classifier.categories.include?('Ruby')
   end
@@ -55,7 +54,7 @@ module BayesianCommonTests
   end
 
   def test_classification_with_threshold
-    b = ClassifierReborn::Bayes.new 'Digit'
+    b = threshold_classifier('Digit')
     assert_equal 1, b.categories.size
 
     refute b.threshold_enabled?
@@ -78,7 +77,7 @@ module BayesianCommonTests
   end
 
   def test_classification_with_threshold_again
-    b = ClassifierReborn::Bayes.new 'Normal'
+    b = threshold_classifier('Normal')
     assert_equal 1, b.categories.size
 
     refute b.threshold_enabled?

--- a/test/bayes/bayesian_common_tests.rb
+++ b/test/bayes/bayesian_common_tests.rb
@@ -1,0 +1,120 @@
+# encoding: utf-8
+
+module BayesianCommonTests
+  def test_good_training
+    assert_nothing_raised { @classifier.train_interesting 'love' }
+  end
+
+  def test_training_with_utf8
+    assert_nothing_raised { @classifier.train_interesting 'Água' }
+  end
+
+  def test_stemming_enabled_by_default
+    assert @classifier.stemmer_enabled?
+  end
+
+  def test_bad_training
+    assert_raise(StandardError) { @classifier.train_no_category 'words' }
+  end
+
+  def test_bad_method
+    assert_raise(NoMethodError) { @classifier.forget_everything_you_know '' }
+  end
+
+  def test_categories
+    assert_equal %w(Interesting Uninteresting).sort, @classifier.categories.sort
+  end
+
+  def test_categories_from_array
+    another_classifier = ClassifierReborn::Bayes.new %w(Interesting Uninteresting)
+    assert_equal another_classifier.categories.sort, @classifier.categories.sort
+  end
+
+  def test_add_category
+    @classifier.add_category 'Test'
+    assert_equal %w(Test Interesting Uninteresting).sort, @classifier.categories.sort
+  end
+
+  def test_dynamic_category_succeeds_with_auto_categorize
+    classifier = ClassifierReborn::Bayes.new 'Interesting', 'Uninteresting', auto_categorize: true
+    classifier.train('Ruby', 'I really sweet language')
+    assert classifier.categories.include?('Ruby')
+  end
+
+  def test_dynamic_category_fails_without_auto_categorize
+    assert_raises(ClassifierReborn::Bayes::CategoryNotFoundError) do
+      @classifier.train('Ruby', 'A really sweet language')
+    end
+    refute @classifier.categories.include?('Ruby')
+  end
+
+  def test_classification
+    @classifier.train_interesting 'here are some good words. I hope you love them'
+    @classifier.train_uninteresting 'here are some bad words, I hate you'
+    assert_equal 'Uninteresting', @classifier.classify('I hate bad words and you')
+  end
+
+  def test_classification_with_threshold
+    b = ClassifierReborn::Bayes.new 'Digit'
+    assert_equal 1, b.categories.size
+
+    refute b.threshold_enabled?
+    b.enable_threshold
+    assert b.threshold_enabled?
+    assert_equal 0.0, b.threshold # default
+
+    b.threshold = -7.0
+
+    10.times do |a_number|
+      b.train_digit(a_number.to_s)
+      b.train_digit(a_number.to_s)
+    end
+
+    10.times do |a_number|
+      assert_equal 'Digit', b.classify(a_number.to_s)
+    end
+
+    refute b.classify('xyzzy')
+  end
+
+  def test_classification_with_threshold_again
+    b = ClassifierReborn::Bayes.new 'Normal'
+    assert_equal 1, b.categories.size
+
+    refute b.threshold_enabled?
+    b.enable_threshold
+    assert b.threshold_enabled?
+    assert_equal 0.0, b.threshold # default
+
+    %w(
+      http://example.com/about
+      http://example.com/contact
+      http://example.com/download
+      http://example.com/login
+      http://example.com/logout
+      http://example.com/blog/2015-04-01
+    ).each do |url|
+      b.train_normal(url)
+    end
+
+    assert 'Normal', b.classify('http://example.com')
+    refute b.classify("http://example.com/login/?user='select * from users;'")
+  end
+
+  def test_classification_with_score
+    @classifier.train_interesting 'here are some good words. I hope you love them'
+    @classifier.train_uninteresting 'here are some bad words, I hate you'
+    assert_in_delta(-4.85, @classifier.classify_with_score('I hate bad words and you')[1], 0.1)
+  end
+
+  def test_untrain
+    @classifier.train_interesting 'here are some good words. I hope you love them'
+    @classifier.train_uninteresting 'here are some bad words, I hate you'
+    @classifier.add_category 'colors'
+    @classifier.train_colors 'red orange green blue seven'
+    classification_of_bad_data = @classifier.classify 'seven'
+    @classifier.untrain_colors 'seven'
+    classification_after_untrain = @classifier.classify 'seven'
+    assert_not_equal classification_of_bad_data, classification_after_untrain
+  end
+end

--- a/test/bayes/bayesian_redis_test.rb
+++ b/test/bayes/bayesian_redis_test.rb
@@ -1,0 +1,134 @@
+# encoding: utf-8
+
+require File.dirname(__FILE__) + '/../test_helper'
+
+class BayesianRedisTest < Test::Unit::TestCase
+  def setup
+    begin
+      @classifier = ClassifierReborn::Bayes.new('Interesting', 'Uninteresting', {backend: ClassifierReborn::BayesRedisBackend.new})
+    rescue Redis::CannotConnectError => e
+      omit(e)
+    end
+  end
+
+  def cleanup
+    @classifier.instance_variable_get(:@backend).instance_variable_get(:@redis).flushdb
+  end
+
+  def test_good_training
+    assert_nothing_raised { @classifier.train_interesting 'love' }
+  end
+
+  def test_training_with_utf8
+    assert_nothing_raised { @classifier.train_interesting 'Água' }
+  end
+
+  def test_stemming_enabled_by_default
+    assert @classifier.stemmer_enabled?
+  end
+
+  def test_bad_training
+    assert_raise(StandardError) { @classifier.train_no_category 'words' }
+  end
+
+  def test_bad_method
+    assert_raise(NoMethodError) { @classifier.forget_everything_you_know '' }
+  end
+
+  def test_categories
+    assert_equal %w(Interesting Uninteresting).sort, @classifier.categories.sort
+  end
+
+  def test_categories_from_array
+    another_classifier = ClassifierReborn::Bayes.new %w(Interesting Uninteresting)
+    assert_equal another_classifier.categories.sort, @classifier.categories.sort
+  end
+
+  def test_add_category
+    @classifier.add_category 'Test'
+    assert_equal %w(Test Interesting Uninteresting).sort, @classifier.categories.sort
+  end
+
+  def test_dynamic_category_succeeds_with_auto_categorize
+    classifier = ClassifierReborn::Bayes.new 'Interesting', 'Uninteresting', auto_categorize: true
+    classifier.train('Ruby', 'I really sweet language')
+    assert classifier.categories.include?('Ruby')
+  end
+
+  def test_dynamic_category_fails_without_auto_categorize
+    assert_raises(ClassifierReborn::Bayes::CategoryNotFoundError) do
+      @classifier.train('Ruby', 'A really sweet language')
+    end
+    refute @classifier.categories.include?('Ruby')
+  end
+
+  def test_classification
+    @classifier.train_interesting 'here are some good words. I hope you love them'
+    @classifier.train_uninteresting 'here are some bad words, I hate you'
+    assert_equal 'Uninteresting', @classifier.classify('I hate bad words and you')
+  end
+
+  def test_classification_with_threshold
+    b = ClassifierReborn::Bayes.new 'Digit'
+    assert_equal 1, b.categories.size
+
+    refute b.threshold_enabled?
+    b.enable_threshold
+    assert b.threshold_enabled?
+    assert_equal 0.0, b.threshold # default
+
+    b.threshold = -7.0
+
+    10.times do |a_number|
+      b.train_digit(a_number.to_s)
+      b.train_digit(a_number.to_s)
+    end
+
+    10.times do |a_number|
+      assert_equal 'Digit', b.classify(a_number.to_s)
+    end
+
+    refute b.classify('xyzzy')
+  end
+
+  def test_classification_with_threshold_again
+    b = ClassifierReborn::Bayes.new 'Normal'
+    assert_equal 1, b.categories.size
+
+    refute b.threshold_enabled?
+    b.enable_threshold
+    assert b.threshold_enabled?
+    assert_equal 0.0, b.threshold # default
+
+    %w(
+      http://example.com/about
+      http://example.com/contact
+      http://example.com/download
+      http://example.com/login
+      http://example.com/logout
+      http://example.com/blog/2015-04-01
+    ).each do |url|
+      b.train_normal(url)
+    end
+
+    assert 'Normal', b.classify('http://example.com')
+    refute b.classify("http://example.com/login/?user='select * from users;'")
+  end
+
+  def test_classification_with_score
+    @classifier.train_interesting 'here are some good words. I hope you love them'
+    @classifier.train_uninteresting 'here are some bad words, I hate you'
+    assert_in_delta(-4.85, @classifier.classify_with_score('I hate bad words and you')[1], 0.1)
+  end
+
+  def test_untrain
+    @classifier.train_interesting 'here are some good words. I hope you love them'
+    @classifier.train_uninteresting 'here are some bad words, I hate you'
+    @classifier.add_category 'colors'
+    @classifier.train_colors 'red orange green blue seven'
+    classification_of_bad_data = @classifier.classify 'seven'
+    @classifier.untrain_colors 'seven'
+    classification_after_untrain = @classifier.classify 'seven'
+    assert_not_equal classification_of_bad_data, classification_after_untrain
+  end
+end

--- a/test/bayes/bayesian_redis_test.rb
+++ b/test/bayes/bayesian_redis_test.rb
@@ -1,8 +1,11 @@
 # encoding: utf-8
 
 require File.dirname(__FILE__) + '/../test_helper'
+require_relative './bayesian_common_tests'
 
 class BayesianRedisTest < Test::Unit::TestCase
+  include BayesianCommonTests
+
   def setup
     begin
       @classifier = ClassifierReborn::Bayes.new('Interesting', 'Uninteresting', {backend: ClassifierReborn::BayesRedisBackend.new})
@@ -13,122 +16,5 @@ class BayesianRedisTest < Test::Unit::TestCase
 
   def cleanup
     @classifier.instance_variable_get(:@backend).instance_variable_get(:@redis).flushdb
-  end
-
-  def test_good_training
-    assert_nothing_raised { @classifier.train_interesting 'love' }
-  end
-
-  def test_training_with_utf8
-    assert_nothing_raised { @classifier.train_interesting 'Água' }
-  end
-
-  def test_stemming_enabled_by_default
-    assert @classifier.stemmer_enabled?
-  end
-
-  def test_bad_training
-    assert_raise(StandardError) { @classifier.train_no_category 'words' }
-  end
-
-  def test_bad_method
-    assert_raise(NoMethodError) { @classifier.forget_everything_you_know '' }
-  end
-
-  def test_categories
-    assert_equal %w(Interesting Uninteresting).sort, @classifier.categories.sort
-  end
-
-  def test_categories_from_array
-    another_classifier = ClassifierReborn::Bayes.new %w(Interesting Uninteresting)
-    assert_equal another_classifier.categories.sort, @classifier.categories.sort
-  end
-
-  def test_add_category
-    @classifier.add_category 'Test'
-    assert_equal %w(Test Interesting Uninteresting).sort, @classifier.categories.sort
-  end
-
-  def test_dynamic_category_succeeds_with_auto_categorize
-    classifier = ClassifierReborn::Bayes.new 'Interesting', 'Uninteresting', auto_categorize: true
-    classifier.train('Ruby', 'I really sweet language')
-    assert classifier.categories.include?('Ruby')
-  end
-
-  def test_dynamic_category_fails_without_auto_categorize
-    assert_raises(ClassifierReborn::Bayes::CategoryNotFoundError) do
-      @classifier.train('Ruby', 'A really sweet language')
-    end
-    refute @classifier.categories.include?('Ruby')
-  end
-
-  def test_classification
-    @classifier.train_interesting 'here are some good words. I hope you love them'
-    @classifier.train_uninteresting 'here are some bad words, I hate you'
-    assert_equal 'Uninteresting', @classifier.classify('I hate bad words and you')
-  end
-
-  def test_classification_with_threshold
-    b = ClassifierReborn::Bayes.new 'Digit'
-    assert_equal 1, b.categories.size
-
-    refute b.threshold_enabled?
-    b.enable_threshold
-    assert b.threshold_enabled?
-    assert_equal 0.0, b.threshold # default
-
-    b.threshold = -7.0
-
-    10.times do |a_number|
-      b.train_digit(a_number.to_s)
-      b.train_digit(a_number.to_s)
-    end
-
-    10.times do |a_number|
-      assert_equal 'Digit', b.classify(a_number.to_s)
-    end
-
-    refute b.classify('xyzzy')
-  end
-
-  def test_classification_with_threshold_again
-    b = ClassifierReborn::Bayes.new 'Normal'
-    assert_equal 1, b.categories.size
-
-    refute b.threshold_enabled?
-    b.enable_threshold
-    assert b.threshold_enabled?
-    assert_equal 0.0, b.threshold # default
-
-    %w(
-      http://example.com/about
-      http://example.com/contact
-      http://example.com/download
-      http://example.com/login
-      http://example.com/logout
-      http://example.com/blog/2015-04-01
-    ).each do |url|
-      b.train_normal(url)
-    end
-
-    assert 'Normal', b.classify('http://example.com')
-    refute b.classify("http://example.com/login/?user='select * from users;'")
-  end
-
-  def test_classification_with_score
-    @classifier.train_interesting 'here are some good words. I hope you love them'
-    @classifier.train_uninteresting 'here are some bad words, I hate you'
-    assert_in_delta(-4.85, @classifier.classify_with_score('I hate bad words and you')[1], 0.1)
-  end
-
-  def test_untrain
-    @classifier.train_interesting 'here are some good words. I hope you love them'
-    @classifier.train_uninteresting 'here are some bad words, I hate you'
-    @classifier.add_category 'colors'
-    @classifier.train_colors 'red orange green blue seven'
-    classification_of_bad_data = @classifier.classify 'seven'
-    @classifier.untrain_colors 'seven'
-    classification_after_untrain = @classifier.classify 'seven'
-    assert_not_equal classification_of_bad_data, classification_after_untrain
   end
 end

--- a/test/bayes/bayesian_redis_test.rb
+++ b/test/bayes/bayesian_redis_test.rb
@@ -8,13 +8,25 @@ class BayesianRedisTest < Minitest::Test
 
   def setup
     begin
-      @classifier = ClassifierReborn::Bayes.new('Interesting', 'Uninteresting', {backend: ClassifierReborn::BayesRedisBackend.new})
+      @classifier = ClassifierReborn::Bayes.new 'Interesting', 'Uninteresting', backend: ClassifierReborn::BayesRedisBackend.new
     rescue Redis::CannotConnectError => e
-      omit(e)
+      skip(e)
     end
   end
 
   def teardown
-    @classifier.instance_variable_get(:@backend).instance_variable_get(:@redis).flushdb
+    @classifier.instance_variable_get(:@backend).instance_variable_get(:@redis).flushall
+  end
+
+  def another_classifier
+    ClassifierReborn::Bayes.new %w(Interesting Uninteresting), backend: ClassifierReborn::BayesRedisBackend.new(db: 1)
+  end
+
+  def auto_categorize_classifier
+    ClassifierReborn::Bayes.new 'Interesting', 'Uninteresting', auto_categorize: true, backend: ClassifierReborn::BayesRedisBackend.new(db: 1)
+  end
+
+  def threshold_classifier(category)
+    ClassifierReborn::Bayes.new category, backend: ClassifierReborn::BayesRedisBackend.new(db: 1)
   end
 end

--- a/test/bayes/bayesian_test.rb
+++ b/test/bayes/bayesian_test.rb
@@ -9,4 +9,16 @@ class BayesianTest < Minitest::Test
   def setup
     @classifier = ClassifierReborn::Bayes.new 'Interesting', 'Uninteresting'
   end
+
+  def another_classifier
+    ClassifierReborn::Bayes.new %w(Interesting Uninteresting)
+  end
+
+  def auto_categorize_classifier
+    ClassifierReborn::Bayes.new 'Interesting', 'Uninteresting', auto_categorize: true
+  end
+
+  def threshold_classifier(category)
+    ClassifierReborn::Bayes.new category
+  end
 end

--- a/test/bayes/bayesian_test.rb
+++ b/test/bayes/bayesian_test.rb
@@ -1,125 +1,12 @@
 # encoding: utf-8
 
 require File.dirname(__FILE__) + '/../test_helper'
+require_relative './bayesian_common_tests'
+
 class BayesianTest < Test::Unit::TestCase
+  include BayesianCommonTests
+
   def setup
     @classifier = ClassifierReborn::Bayes.new 'Interesting', 'Uninteresting'
-  end
-
-  def test_good_training
-    assert_nothing_raised { @classifier.train_interesting 'love' }
-  end
-
-  def test_training_with_utf8
-    assert_nothing_raised { @classifier.train_interesting 'Água' }
-  end
-
-  def test_stemming_enabled_by_default
-    assert @classifier.stemmer_enabled?
-  end
-
-  def test_bad_training
-    assert_raise(StandardError) { @classifier.train_no_category 'words' }
-  end
-
-  def test_bad_method
-    assert_raise(NoMethodError) { @classifier.forget_everything_you_know '' }
-  end
-
-  def test_categories
-    assert_equal %w(Interesting Uninteresting).sort, @classifier.categories.sort
-  end
-
-  def test_categories_from_array
-    another_classifier = ClassifierReborn::Bayes.new %w(Interesting Uninteresting)
-    assert_equal another_classifier.categories.sort, @classifier.categories.sort
-  end
-
-  def test_add_category
-    @classifier.add_category 'Test'
-    assert_equal %w(Test Interesting Uninteresting).sort, @classifier.categories.sort
-  end
-
-  def test_dynamic_category_succeeds_with_auto_categorize
-    classifier = ClassifierReborn::Bayes.new 'Interesting', 'Uninteresting', auto_categorize: true
-    classifier.train('Ruby', 'I really sweet language')
-    assert classifier.categories.include?('Ruby')
-  end
-
-  def test_dynamic_category_fails_without_auto_categorize
-    assert_raises(ClassifierReborn::Bayes::CategoryNotFoundError) do
-      @classifier.train('Ruby', 'A really sweet language')
-    end
-    refute @classifier.categories.include?('Ruby')
-  end
-
-  def test_classification
-    @classifier.train_interesting 'here are some good words. I hope you love them'
-    @classifier.train_uninteresting 'here are some bad words, I hate you'
-    assert_equal 'Uninteresting', @classifier.classify('I hate bad words and you')
-  end
-
-  def test_classification_with_threshold
-    b = ClassifierReborn::Bayes.new 'Digit'
-    assert_equal 1, b.categories.size
-
-    refute b.threshold_enabled?
-    b.enable_threshold
-    assert b.threshold_enabled?
-    assert_equal 0.0, b.threshold # default
-
-    b.threshold = -7.0
-
-    10.times do |a_number|
-      b.train_digit(a_number.to_s)
-      b.train_digit(a_number.to_s)
-    end
-
-    10.times do |a_number|
-      assert_equal 'Digit', b.classify(a_number.to_s)
-    end
-
-    refute b.classify('xyzzy')
-  end
-
-  def test_classification_with_threshold_again
-    b = ClassifierReborn::Bayes.new 'Normal'
-    assert_equal 1, b.categories.size
-
-    refute b.threshold_enabled?
-    b.enable_threshold
-    assert b.threshold_enabled?
-    assert_equal 0.0, b.threshold # default
-
-    %w(
-      http://example.com/about
-      http://example.com/contact
-      http://example.com/download
-      http://example.com/login
-      http://example.com/logout
-      http://example.com/blog/2015-04-01
-    ).each do |url|
-      b.train_normal(url)
-    end
-
-    assert 'Normal', b.classify('http://example.com')
-    refute b.classify("http://example.com/login/?user='select * from users;'")
-  end
-
-  def test_classification_with_score
-    @classifier.train_interesting 'here are some good words. I hope you love them'
-    @classifier.train_uninteresting 'here are some bad words, I hate you'
-    assert_in_delta(-4.85, @classifier.classify_with_score('I hate bad words and you')[1], 0.1)
-  end
-
-  def test_untrain
-    @classifier.train_interesting 'here are some good words. I hope you love them'
-    @classifier.train_uninteresting 'here are some bad words, I hate you'
-    @classifier.add_category 'colors'
-    @classifier.train_colors 'red orange green blue seven'
-    classification_of_bad_data = @classifier.classify 'seven'
-    @classifier.untrain_colors 'seven'
-    classification_after_untrain = @classifier.classify 'seven'
-    assert_not_equal classification_of_bad_data, classification_after_untrain
   end
 end


### PR DESCRIPTION
This WIP PR is to support #81

## TODO

* [x] Refactor Bayes classifier code to extract all the persistent states and data structures away
* [x] Conditional initialization of the backends (Memory or Redis)
* [x] Meaningful proxy read and write method names to allow uniform backend API
* [x] Change in data structure for better generalization
* [x] Implementation of the Memory backend
* [x] Passing existing Bayes Memory tests
* [x] Implementation of the Redis backend
* [x] Writing Bayes tests for Redis backend
* [x] DRY test cases for both the backends
* [x] Writing tests for both backend classes
* [x] Add Redis in Travis CI
* [x] Update README
* [ ] Code review
