### PR TITLE
Speed up Docker image rebilding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ MAINTAINER Sawood Alam <https://github.com/ibnesayeed>
 ENV LANG C.UTF-8
 
 RUN apt update && apt install -y libgsl0-dev && rm -rf /var/lib/apt/lists/*
+RUN gem install narray nmatrix gsl redis
 
 RUN cd /tmp \
     && wget http://download.redis.io/redis-stable.tar.gz \
@@ -15,6 +16,5 @@ RUN cd /tmp \
 WORKDIR /usr/src/app
 COPY . /usr/src/app
 RUN bundle install
-RUN gem install narray nmatrix gsl redis
 
 CMD redis-server --daemonize yes && rake

--- a/test/bayes/bayesian_common_benchmarks.rb
+++ b/test/bayes/bayesian_common_benchmarks.rb
@@ -17,10 +17,6 @@ module BayesianCommonBenchmarks
     (Minitest::Benchmark.bench_exp(1, MAX_RECORDS) << MAX_RECORDS).uniq
   end
 
-  def self.data
-    @@data ||= self.load_data
-  end
-
   def insufficient_data?
     @data.length < MAX_RECORDS
   end


### PR DESCRIPTION
By moving the less frequently changing independent layer up, we can utilize cache to speed up the image building process.