### PR TITLE
Fixed error on requiring 'classifier-reborn' without using Redis

### DIFF
--- a/lib/classifier-reborn/backends/bayes_redis_backend.rb
+++ b/lib/classifier-reborn/backends/bayes_redis_backend.rb
@@ -1,3 +1,5 @@
+require_relative 'no_redis_error'
+
 begin
   require 'redis'
 rescue LoadError

--- a/lib/classifier-reborn/bayes.rb
+++ b/lib/classifier-reborn/bayes.rb
@@ -6,7 +6,6 @@ require 'set'
 
 require_relative 'category_namer'
 require_relative 'backends/bayes_memory_backend'
-require_relative 'backends/bayes_redis_backend'
 
 module ClassifierReborn
   class Bayes

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,4 +6,5 @@ require 'minitest/reporters'
 Minitest::Reporters.use! Minitest::Reporters::SpecReporter.new
 require 'pry'
 require 'classifier-reborn'
+require 'classifier-reborn/backends/bayes_redis_backend'
 include ClassifierReborn


### PR DESCRIPTION
I have tried to use the gem without using redis and got this error
```
Bundler::GemRequireError: There was an error while trying to load the gem 'classifier-reborn'.
Gem Load Error is: uninitialized constant NoRedisError
Backtrace for gem load error is:
/mnt/d/documents/projects/classifier-reborn/lib/classifier-reborn/backends/bayes_redis_backend.rb:4:in `rescue in <top (required)>'
/mnt/d/documents/projects/classifier-reborn/lib/classifier-reborn/backends/bayes_redis_backend.rb:1:in `<top (required)>'
/mnt/d/documents/projects/classifier-reborn/lib/classifier-reborn/bayes.rb:9:in `require_relative'
/mnt/d/documents/projects/classifier-reborn/lib/classifier-reborn/bayes.rb:9:in `<top (required)>'
/mnt/d/documents/projects/classifier-reborn/lib/classifier-reborn.rb:29:in `require_relative'
/mnt/d/documents/projects/classifier-reborn/lib/classifier-reborn.rb:29:in `<top (required)>'
```

I think that we need to manually require `classifier-reborn/backends/bayes_redis_backend` before using redis backend.
