### PR TITLE
fix sqrt issue when there is only one char various in traindata

### DIFF
--- a/lib/classifier-reborn/extensions/hasher.rb
+++ b/lib/classifier-reborn/extensions/hasher.rb
@@ -27,7 +27,7 @@ module ClassifierReborn
     def word_hash_for_words(words, language = 'en', enable_stemmer = true)
       d = Hash.new(0)
       words.each do |word|
-        next unless word.length > 2 && !STOPWORDS[language].include?(word)
+        next unless word.length > 0 && !STOPWORDS[language].include?(word)
         if enable_stemmer
           d[word.stem.intern] += 1
         else

--- a/test/bayes/bayesian_common_tests.rb
+++ b/test/bayes/bayesian_common_tests.rb
@@ -139,10 +139,10 @@ module BayesianCommonTests
     classifier.train('Ruby', '')
     assert classifier.categories.empty?
     classifier.train('Ruby', 'To be or not to be')
-    assert classifier.categories.empty?
+    refute classifier.categories.empty?
     classifier.train('Ruby', 'A really sweet language')
     refute classifier.categories.empty?
-    assert_equal Float::INFINITY, classifier.classify_with_score('To be or not to be')[1]
+    assert_equal Float::INFINITY, classifier.classify_with_score('')[1]
   end
 
   def test_empty_string_stopwords

--- a/test/extensions/hasher_test.rb
+++ b/test/extensions/hasher_test.rb
@@ -56,7 +56,7 @@ class HasherTest < Minitest::Test
     temp_stopwords_name = File.basename(temp_stopwords.path)
 
     Hasher.add_custom_stopword_path(temp_stopwords_path)
-    hash = { list: 1, cool: 1 }
+    hash = {:is=>1, :a=>1, :list=>1, :of=>1, :cool=>1}
     assert_equal hash, Hasher.clean_word_hash("this is a list of cool words!", temp_stopwords_name)
   end
 


### PR DESCRIPTION
this is a fix for below issue 
```
lsi = ClassifierReborn::LSI.new
lsi.add_item 'log message Error: 1', :Error
lsi.add_item 'log message Error: 0', :passenger_ship: 
result  = lsi.classify 'log message Error: 1'
```
then the sqrt will have error when do the svd operation.

```
D:/projects/P_hobbit/AI/log_classifier/lib/classifier-reborn/extensions/vector.rb:58:in `sqrt': Numerical argument is out of domain - "sqrt" (Math::DomainError)
	from D:/projects/P_hobbit/AI/log_classifier/lib/classifier-reborn/extensions/vector.rb:58:in `block in SV_decomp'
	from D:/projects/P_hobbit/AI/log_classifier/lib/classifier-reborn/extensions/vector.rb:57:in `times'
	from D:/projects/P_hobbit/AI/log_classifier/lib/classifier-reborn/extensions/vector.rb:57:in `SV_decomp'
	from D:/projects/P_hobbit/AI/log_classifier/lib/classifier-reborn/lsi.rb:311:in `build_reduced_matrix'
	from D:/projects/P_hobbit/AI/log_classifier/lib/classifier-reborn/lsi.rb:143:in `build_index'
	from D:/projects/P_hobbit/AI/log_classifier/lib/classifier-reborn/lsi.rb:77:in `add_item'
	from D:/projects/P_hobbit/AI/log_classifier/pass_fail.rb:34:in `<main>'
```

Signed-off-by: Hake Huang <hakehuang@gmail.com>