### PR TITLE
Set Redis keys only if they don't exist

### DIFF
--- a/lib/classifier-reborn/backends/bayes_redis_backend.rb
+++ b/lib/classifier-reborn/backends/bayes_redis_backend.rb
@@ -31,8 +31,8 @@ module ClassifierReborn
     #   inherit_socket:     false
     def initialize(options = {})
       @redis = Redis.new(options)
-      @redis.set(:total_words, 0)
-      @redis.set(:total_trainings, 0)
+      @redis.setnx(:total_words, 0)
+      @redis.setnx(:total_trainings, 0)
     end
 
     def total_words


### PR DESCRIPTION
My use case is to train a model in Redis and then periodically reconnect to the model to classify a thing. For some reason every time I would reconnect, classifications have confidences of Infinity. Then I found out that initializing a BayesRedisBackend was resetting the total_words and total_trainings keys.