### PR TITLE
Require bayes_redis_backend

### DIFF
--- a/lib/classifier-reborn/backends/bayes_redis_backend.rb
+++ b/lib/classifier-reborn/backends/bayes_redis_backend.rb
@@ -1,10 +1,7 @@
 require_relative 'no_redis_error'
-
-begin
-  require 'redis'
-rescue LoadError
-  raise NoRedisError
-end
+# require redis when we run #intialize. This way only people using this backend
+# will need to install and load the backend without having to
+# require 'classifier-reborn/backends/bayes_redis_backend'
 
 module ClassifierReborn
   # This class provides Redis as the storage backend for the classifier data structures
@@ -30,6 +27,12 @@ module ClassifierReborn
     #   reconnect_attempts: 1
     #   inherit_socket:     false
     def initialize(options = {})
+      begin # because some people don't have redis installed
+        require 'redis'
+      rescue LoadError
+        raise NoRedisError
+      end
+
       @redis = Redis.new(options)
       @redis.set(:total_words, 0)
       @redis.set(:total_trainings, 0)

--- a/lib/classifier-reborn/bayes.rb
+++ b/lib/classifier-reborn/bayes.rb
@@ -6,6 +6,7 @@ require 'set'
 
 require_relative 'category_namer'
 require_relative 'backends/bayes_memory_backend'
+require_relative 'backends/bayes_redis_backend'
 
 module ClassifierReborn
   class Bayes


### PR DESCRIPTION
`require_relative 'backends/bayes_redis_backend'` was removed from bayes.rb because of https://github.com/jekyll/classifier-reborn/pull/146, but having to manually `require 'classifier-reborn/backends/bayes_redis_backend'` is kind of annoying.

Putting `require 'redis'` inside BayesRedisBackend#initialize is a solution, but it's kind of gross. 

Maybe there is a better one?