### PR TITLE
Separate tokenizer from hasher

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -21,7 +21,7 @@ task default: [:test]
 desc 'Run all unit tests'
 Rake::TestTask.new(:test) do |t|
   t.libs << 'lib'
-  t.pattern = 'test/*/*_test.rb'
+  t.pattern = 'test/**/*_test.rb'
   t.verbose = true
 end
 
@@ -29,7 +29,7 @@ end
 desc 'Run all benchmarks'
 Rake::TestTask.new(:bench) do |t|
   t.libs << 'lib'
-  t.pattern = 'test/*/*_benchmark.rb'
+  t.pattern = 'test/**/*_benchmark.rb'
   t.verbose = true
 end
 

--- a/classifier-reborn.gemspec
+++ b/classifier-reborn.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.summary          = 'A general classifier module to allow Bayesian and other types of classifications.'
   s.authors          = ['Lucas Carlson', 'Parker Moore', 'Chase Gilliam']
   s.email            = ['lucas@rufy.com', 'parkrmoore@gmail.com', 'chase.gilliam@gmail.com']
-  s.homepage         = 'www.classifier-reborn.com'
+  s.homepage         = 'http://www.classifier-reborn.com'
 
   all_files          = `git ls-files -z`.split("\x0")
   s.files            = all_files.grep(%r{^(bin|lib|data)/})

--- a/docs/bayes.md
+++ b/docs/bayes.md
@@ -139,7 +139,7 @@ classifier.train("Dog", "I don't always bark at night")
 
 By default the classifier tokenizes given inputs as a white-space separeted terms.
 If you want to use different tokenizer, give it via the `:tokenizer` option.
-Tokenizer must be a module having a module function named `tokenize`.
+Tokenizer must be an object having a module function named `call`, or a lambda.
 The function must return tokens as instances of `ClassifierReborn::Tokenizer::Token`.
 
 ```ruby
@@ -147,7 +147,7 @@ require 'classifier-reborn'
 
 module BigramTokenizer
   module_function
-  def tokenize(str)
+  def call(str)
     str.each_char
        .each_cons(2)
        .map do |chars| ClassifierReborn::Tokenizer::Token.new(chars.join) end
@@ -157,28 +157,48 @@ end
 classifier = ClassifierReborn::Bayes.new tokenizer: BigramTokenizer
 ```
 
+or
+
+```ruby
+require 'classifier-reborn'
+
+bigram_tokenizer = lambda do |str|
+  str.each_char
+     .each_cons(2)
+     .map do |chars| ClassifierReborn::Tokenizer::Token.new(chars.join) end
+end
+
+classifier = ClassifierReborn::Bayes.new tokenizer: bigram_tokenizer
+```
 
 ## Custom Token Filters
 
 By default classifier rejects stopwords from tokens.
 This behavior is implemented based on filters for tokens.
 If you want to use more token filters, give them via the `:token_filter` option.
-A filter must be a module having a module function named `filter`.
+A filter must be an object having a module function named `call`, or a lambda.
 
 ```ruby
 require 'classifier-reborn'
 
 module CatFilter
   module_function
-  def filter(tokens)
+  def call(tokens)
     tokens.reject do |token|
-      /\Acat\z/i === token
+      /cat/i === token
     end
   end
 end
 
+white_filter = lambda do |tokens|
+  tokens.reject do |token|
+    /white/i === token
+  end
+done
+
 filters = [
   CatFilter,
+  white_filter
   # If you want to reject stopwords too, you need to include stopword filter
   # to the list of token filters manually.
   ClassifierReborn::TokenFilters::Stopword,

--- a/docs/bayes.md
+++ b/docs/bayes.md
@@ -156,6 +156,8 @@ end
 classifier = ClassifierReborn::Bayes.new tokenizer: BigramTokenizer
 ```
 
+Custom tokenizer must return tokens as instances of `ClassifierReborn::Tokenizer::Token`.
+
 ## Custom Token Filters
 
 By default classifier rejects stopwords from tokens.

--- a/docs/bayes.md
+++ b/docs/bayes.md
@@ -140,6 +140,7 @@ classifier.train("Dog", "I don't always bark at night")
 By default the classifier tokenizes given inputs as a white-space separeted terms.
 If you want to use different tokenizer, give it via the `:tokenizer` option.
 Tokenizer must be a module having a module function named `tokenize`.
+The function must return tokens as instances of `ClassifierReborn::Tokenizer::Token`.
 
 ```ruby
 require 'classifier-reborn'
@@ -156,7 +157,6 @@ end
 classifier = ClassifierReborn::Bayes.new tokenizer: BigramTokenizer
 ```
 
-Custom tokenizer must return tokens as instances of `ClassifierReborn::Tokenizer::Token`.
 
 ## Custom Token Filters
 

--- a/docs/bayes.md
+++ b/docs/bayes.md
@@ -135,6 +135,27 @@ classifier.train("Cat", "I can has cat")
 classifier.train("Dog", "I don't always bark at night")
 ```
 
+## Custom Tokenizers
+
+By default the classifier tokenizes given inputs as a white-space separeted terms.
+If you want to use different tokenizer, give it via the `:tokenizer` option.
+Tokenizer must be a module having a module function named `tokenize`.
+
+```ruby
+require 'classifier-reborn'
+
+module BigramTokenizer
+  module_function
+  def tokenize(str, clean: false)
+    str.each_char
+       .each_cons(2)
+       .map do |chars| chars.join end
+  end
+end
+
+classifier = ClassifierReborn::Bayes.new tokenizer: BigramTokenizer
+```
+
 ## Custom Stopwords
 
 The library ships with stopword files in various languages.

--- a/docs/bayes.md
+++ b/docs/bayes.md
@@ -149,7 +149,7 @@ module BigramTokenizer
   def tokenize(str)
     str.each_char
        .each_cons(2)
-       .map do |chars| chars.join end
+       .map do |chars| ClassifierReborn::Tokenizer::Token.new(chars.join) end
   end
 end
 

--- a/docs/bayes.md
+++ b/docs/bayes.md
@@ -135,7 +135,7 @@ classifier.train("Cat", "I can has cat")
 classifier.train("Dog", "I don't always bark at night")
 ```
 
-## Custom Tokenizers
+## Custom Tokenizer
 
 By default the classifier tokenizes given inputs as a white-space separeted terms.
 If you want to use different tokenizer, give it via the `:tokenizer` option.

--- a/docs/bayes.md
+++ b/docs/bayes.md
@@ -139,7 +139,7 @@ classifier.train("Dog", "I don't always bark at night")
 
 By default the classifier tokenizes given inputs as a white-space separeted terms.
 If you want to use different tokenizer, give it via the `:tokenizer` option.
-Tokenizer must be an object having a module function named `call`, or a lambda.
+Tokenizer must be an object having a method named `call`, or a lambda.
 The function must return tokens as instances of `ClassifierReborn::Tokenizer::Token`.
 
 ```ruby
@@ -176,7 +176,7 @@ classifier = ClassifierReborn::Bayes.new tokenizer: bigram_tokenizer
 By default classifier rejects stopwords from tokens.
 This behavior is implemented based on filters for tokens.
 If you want to use more token filters, give them via the `:token_filter` option.
-A filter must be an object having a module function named `call`, or a lambda.
+A filter must be an object having a method named `call`, or a lambda.
 
 ```ruby
 require 'classifier-reborn'

--- a/docs/bayes.md
+++ b/docs/bayes.md
@@ -156,6 +156,34 @@ end
 classifier = ClassifierReborn::Bayes.new tokenizer: BigramTokenizer
 ```
 
+## Custom Token Filters
+
+By default classifier rejects stopwords from tokens.
+This behavior is implemented based on filters for tokens.
+If you want to use more token filters, give them via the `:token_filter` option.
+A filter must be a module having a module function named `filter`.
+
+```ruby
+require 'classifier-reborn'
+
+module CatFilter
+  module_function
+  def filter(tokens)
+    tokens.reject do |token|
+      token == "cat"
+    end
+  end
+end
+
+filters = [
+  CatFilter,
+  # If you want to reject stopwords too, you need to include stopword filter
+  # to the list of token filters manually.
+  ClassifierReborn::TokenFilters::Stopword,
+]
+classifier = ClassifierReborn::Bayes.new token_filters: filters
+```
+
 ## Custom Stopwords
 
 The library ships with stopword files in various languages.

--- a/docs/bayes.md
+++ b/docs/bayes.md
@@ -170,7 +170,7 @@ module CatFilter
   module_function
   def filter(tokens)
     tokens.reject do |token|
-      token == "cat"
+      /\Acat\z/i === token
     end
   end
 end

--- a/docs/bayes.md
+++ b/docs/bayes.md
@@ -146,7 +146,7 @@ require 'classifier-reborn'
 
 module BigramTokenizer
   module_function
-  def tokenize(str, clean: false)
+  def tokenize(str)
     str.each_char
        .each_cons(2)
        .map do |chars| chars.join end

--- a/lib/classifier-reborn/bayes.rb
+++ b/lib/classifier-reborn/bayes.rb
@@ -4,6 +4,9 @@
 
 require 'set'
 
+require_relative 'tokenizer/whitespace'
+require_relative 'token_filter/stopword'
+require_relative 'token_filter/stemmer'
 require_relative 'category_namer'
 require_relative 'backends/bayes_memory_backend'
 require_relative 'backends/bayes_redis_backend'

--- a/lib/classifier-reborn/bayes.rb
+++ b/lib/classifier-reborn/bayes.rb
@@ -266,7 +266,7 @@ module ClassifierReborn
           return # Do not overwrite the default
         end
       end
-      Hasher::STOPWORDS[@language] = Set.new stopwords
+      TokenFilter::Stopword::STOPWORDS[@language] = Set.new stopwords
     end
   end
 end

--- a/lib/classifier-reborn/bayes.rb
+++ b/lib/classifier-reborn/bayes.rb
@@ -4,9 +4,9 @@
 
 require 'set'
 
-require_relative 'tokenizer/whitespace'
-require_relative 'token_filter/stopword'
-require_relative 'token_filter/stemmer'
+require_relative 'extensions/tokenizer/whitespace'
+require_relative 'extensions/token_filter/stopword'
+require_relative 'extensions/token_filter/stemmer'
 require_relative 'category_namer'
 require_relative 'backends/bayes_memory_backend'
 require_relative 'backends/bayes_redis_backend'

--- a/lib/classifier-reborn/bayes.rb
+++ b/lib/classifier-reborn/bayes.rb
@@ -52,7 +52,7 @@ module ClassifierReborn
       @backend             = options[:backend]
       @tokenizer           = options[:tokenizer] || Tokenizer::Whitespace
       @token_filters       = options[:token_filters] || [TokenFilter::Stopword]
-      if @enable_stemmer and not @token_filters.include?(TokenFilter::Stemmer)
+      if @enable_stemmer && !@token_filters.include?(TokenFilter::Stemmer)
         @token_filters << TokenFilter::Stemmer
       end
 

--- a/lib/classifier-reborn/bayes.rb
+++ b/lib/classifier-reborn/bayes.rb
@@ -58,6 +58,9 @@ module ClassifierReborn
       if @enable_stemmer && !@token_filters.include?(TokenFilter::Stemmer)
         @token_filters << TokenFilter::Stemmer
       end
+      if @token_filters.include?(TokenFilter::Stopword)
+        TokenFilter::Stopword.language = @language
+      end
 
       populate_initial_categories
 
@@ -73,7 +76,7 @@ module ClassifierReborn
     #     b.train "that", "That text"
     #     b.train "The other", "The other text"
     def train(category, text)
-      word_hash = Hasher.word_hash(text, @language, @enable_stemmer,
+      word_hash = Hasher.word_hash(text, @enable_stemmer,
                                    tokenizer: @tokenizer, token_filters: @token_filters)
       return if word_hash.empty?
       category = CategoryNamer.prepare_name(category)
@@ -104,7 +107,7 @@ module ClassifierReborn
     #     b.train :this, "This text"
     #     b.untrain :this, "This text"
     def untrain(category, text)
-      word_hash = Hasher.word_hash(text, @language, @enable_stemmer,
+      word_hash = Hasher.word_hash(text, @enable_stemmer,
                                    tokenizer: @tokenizer, token_filters: @token_filters)
       return if word_hash.empty?
       category = CategoryNamer.prepare_name(category)
@@ -130,7 +133,7 @@ module ClassifierReborn
     # The largest of these scores (the one closest to 0) is the one picked out by #classify
     def classifications(text)
       score = {}
-      word_hash = Hasher.word_hash(text, @language, @enable_stemmer,
+      word_hash = Hasher.word_hash(text, @enable_stemmer,
                                    tokenizer: @tokenizer, token_filters: @token_filters)
       if word_hash.empty?
         category_keys.each do |category|

--- a/lib/classifier-reborn/extensions/hasher.rb
+++ b/lib/classifier-reborn/extensions/hasher.rb
@@ -18,10 +18,6 @@ module ClassifierReborn
     def word_hash(str, language = 'en', enable_stemmer = true, clean: false,
                   tokenizer: Tokenizer::Whitespace,
                   token_filters: [])
-      tikenize_options = {
-        language: language,
-        clean:    clean,
-      }
       if token_filters.include?(TokenFilter::Stemmer)
         unless enable_stemmer
           token_filters.reject! do |token_filter|
@@ -31,9 +27,9 @@ module ClassifierReborn
       else
         token_filters << TokenFilter::Stemmer if enable_stemmer
       end
-      words = tokenizer.tokenize(str, tikenize_options)
+      words = tokenizer.tokenize(str, clean: clean)
       token_filters.each do |token_filter|
-        words = token_filter.filter(words, tikenize_options)
+        words = token_filter.filter(words, language: language)
       end
       d = Hash.new(0)
       words.each do |word|

--- a/lib/classifier-reborn/extensions/hasher.rb
+++ b/lib/classifier-reborn/extensions/hasher.rb
@@ -17,7 +17,7 @@ module ClassifierReborn
     # interned, and indexes to its frequency in the document.
     def word_hash(str, language = 'en', enable_stemmer = true, clean: false,
                   tokenizer: Tokenizer::Whitespace,
-                  token_filters: [])
+                  token_filters: [TokenFilter::Stopword])
       if token_filters.include?(TokenFilter::Stemmer)
         unless enable_stemmer
           token_filters.reject! do |token_filter|

--- a/lib/classifier-reborn/extensions/hasher.rb
+++ b/lib/classifier-reborn/extensions/hasher.rb
@@ -15,13 +15,18 @@ module ClassifierReborn
 
     # Return a Hash of strings => ints. Each word in the string is stemmed,
     # interned, and indexes to its frequency in the document.
-    def word_hash(str, language = 'en', enable_stemmer = true, clean: false)
-      words = Tokenizer::Whitespace.tokenize(str, clean: clean)
-      words = TokenFilter::Stopword.filter(words, language: language)
-      if enable_stemmer
-        words = TokenFilter::Stemmer.filter(words, language: language)
+    def word_hash(str, language = 'en', enable_stemmer = true, clean: false,
+                  tokenizer: Tokenizer::Whitespace,
+                  token_filters: [])
+      tikenize_options = {
+        language:       language,
+        enable_stemmer: enable_stemmer,
+        clean:          clean,
+      }
+      words = tokenizer.tokenize(str, tikenize_options)
+      token_filters.each do |token_filter|
+        words = token_filter.filter(words, tikenize_options)
       end
-
       d = Hash.new(0)
       words.each do |word|
         d[word.intern] += 1

--- a/lib/classifier-reborn/extensions/hasher.rb
+++ b/lib/classifier-reborn/extensions/hasher.rb
@@ -16,7 +16,12 @@ module ClassifierReborn
     # Return a Hash of strings => ints. Each word in the string is stemmed,
     # interned, and indexes to its frequency in the document.
     def word_hash(str, language = 'en', enable_stemmer = true, clean: false)
-      words = Tokenizer::Whitespace.tokenize(str, language: language, enable_stemmer: enable_stemmer, clean: clean)
+      words = Tokenizer::Whitespace.tokenize(str, clean: clean)
+      words = TokenFilter::Stopword.filter(words, language: language)
+      if enable_stemmer
+        words = TokenFilter::Stemmer.filter(words, language: language)
+      end
+
       d = Hash.new(0)
       words.each do |word|
         d[word.intern] += 1

--- a/lib/classifier-reborn/extensions/hasher.rb
+++ b/lib/classifier-reborn/extensions/hasher.rb
@@ -27,9 +27,9 @@ module ClassifierReborn
       else
         token_filters << TokenFilter::Stemmer if enable_stemmer
       end
-      words = tokenizer.tokenize(str)
+      words = tokenizer.call(str)
       token_filters.each do |token_filter|
-        words = token_filter.filter(words)
+        words = token_filter.call(words)
       end
       d = Hash.new(0)
       words.each do |word|

--- a/lib/classifier-reborn/extensions/hasher.rb
+++ b/lib/classifier-reborn/extensions/hasher.rb
@@ -16,12 +16,7 @@ module ClassifierReborn
     # Return a Hash of strings => ints. Each word in the string is stemmed,
     # interned, and indexes to its frequency in the document.
     def word_hash(str, language = 'en', enable_stemmer = true, clean: false)
-      words = Tokenizer::Whitespace.tokenize(str, clean: clean)
-      words = TokenFilter::Stopword.filter(words, language: language)
-      if enable_stemmer
-        words = TokenFilter::Stemmer.filter(words, language: language)
-      end
-
+      words = Tokenizer::Whitespace.tokenize(str, language: language, enable_stemmer: enable_stemmer, clean: clean)
       d = Hash.new(0)
       words.each do |word|
         d[word.intern] += 1

--- a/lib/classifier-reborn/extensions/hasher.rb
+++ b/lib/classifier-reborn/extensions/hasher.rb
@@ -15,7 +15,7 @@ module ClassifierReborn
 
     # Return a Hash of strings => ints. Each word in the string is stemmed,
     # interned, and indexes to its frequency in the document.
-    def word_hash(str, language = 'en', enable_stemmer = true,
+    def word_hash(str, enable_stemmer = true,
                   tokenizer: Tokenizer::Whitespace,
                   token_filters: [TokenFilter::Stopword])
       if token_filters.include?(TokenFilter::Stemmer)
@@ -29,7 +29,7 @@ module ClassifierReborn
       end
       words = tokenizer.tokenize(str)
       token_filters.each do |token_filter|
-        words = token_filter.filter(words, language: language)
+        words = token_filter.filter(words)
       end
       d = Hash.new(0)
       words.each do |word|

--- a/lib/classifier-reborn/extensions/hasher.rb
+++ b/lib/classifier-reborn/extensions/hasher.rb
@@ -7,6 +7,7 @@ require 'set'
 
 require_relative 'tokenizer/whitespace'
 require_relative 'token_filter/stopword'
+require_relative 'token_filter/stemmer'
 
 module ClassifierReborn
   module Hasher
@@ -15,34 +16,15 @@ module ClassifierReborn
     # Return a Hash of strings => ints. Each word in the string is stemmed,
     # interned, and indexes to its frequency in the document.
     def word_hash(str, language = 'en', enable_stemmer = true)
-      cleaned_word_hash = clean_word_hash(str, language, enable_stemmer)
-      symbol_hash = word_hash_for_symbols(str.scan(/[^\s\p{WORD}]/))
-      cleaned_word_hash.merge(symbol_hash)
-    end
-
-    # Return a word hash without extra punctuation or short symbols, just stemmed words
-    def clean_word_hash(str, language = 'en', enable_stemmer = true)
       words = Tokenizer::Whitespace.tokenize(str)
-      words = TokenFilter::Stopword.filter(words, language)
-      word_hash_for_words(words, language, enable_stemmer)
-    end
-
-    def word_hash_for_words(words, language = 'en', enable_stemmer = true)
-      d = Hash.new(0)
-      words.each do |word|
-        if enable_stemmer
-          d[word.stem.intern] += 1
-        else
-          d[word.intern] += 1
-        end
+      if enable_stemmer
+        words = TokenFilter::Stemmer.filter(words, language)
       end
-      d
-    end
+      words = TokenFilter::Stopword.filter(words, language)
 
-    def word_hash_for_symbols(words)
       d = Hash.new(0)
       words.each do |word|
-        d[word.intern] += 1
+        d[word.to_s.intern] += 1
       end
       d
     end

--- a/lib/classifier-reborn/extensions/hasher.rb
+++ b/lib/classifier-reborn/extensions/hasher.rb
@@ -19,10 +19,18 @@ module ClassifierReborn
                   tokenizer: Tokenizer::Whitespace,
                   token_filters: [])
       tikenize_options = {
-        language:       language,
-        enable_stemmer: enable_stemmer,
-        clean:          clean,
+        language: language,
+        clean:    clean,
       }
+      if token_filters.include?(TokenFilter::Stemmer)
+        unless enable_stemmer
+          token_filters.reject! do |token_filter|
+            token_filter == TokenFilter::Stemmer
+          end
+        end
+      else
+        token_filters << TokenFilter::Stemmer if enable_stemmer
+      end
       words = tokenizer.tokenize(str, tikenize_options)
       token_filters.each do |token_filter|
         words = token_filter.filter(words, tikenize_options)

--- a/lib/classifier-reborn/extensions/hasher.rb
+++ b/lib/classifier-reborn/extensions/hasher.rb
@@ -24,7 +24,7 @@ module ClassifierReborn
 
       d = Hash.new(0)
       words.each do |word|
-        d[word.to_s.intern] += 1
+        d[word.intern] += 1
       end
       d
     end

--- a/lib/classifier-reborn/extensions/hasher.rb
+++ b/lib/classifier-reborn/extensions/hasher.rb
@@ -5,6 +5,8 @@
 
 require 'set'
 
+require_relative 'tokenizer/whitespace'
+
 module ClassifierReborn
   module Hasher
     STOPWORDS_PATH = [File.expand_path(File.dirname(__FILE__) + '/../../../data/stopwords')]
@@ -21,7 +23,8 @@ module ClassifierReborn
 
     # Return a word hash without extra punctuation or short symbols, just stemmed words
     def clean_word_hash(str, language = 'en', enable_stemmer = true)
-      word_hash_for_words(str.gsub(/[^\p{WORD}\s]/, '').downcase.split, language, enable_stemmer)
+      words = Tokenizer::Whitespace.tokenize(str)
+      word_hash_for_words(words, language, enable_stemmer)
     end
 
     def word_hash_for_words(words, language = 'en', enable_stemmer = true)

--- a/lib/classifier-reborn/extensions/hasher.rb
+++ b/lib/classifier-reborn/extensions/hasher.rb
@@ -15,12 +15,12 @@ module ClassifierReborn
 
     # Return a Hash of strings => ints. Each word in the string is stemmed,
     # interned, and indexes to its frequency in the document.
-    def word_hash(str, language = 'en', enable_stemmer = true)
-      words = Tokenizer::Whitespace.tokenize(str)
+    def word_hash(str, language = 'en', enable_stemmer = true, clean: false)
+      words = Tokenizer::Whitespace.tokenize(str, clean: clean)
+      words = TokenFilter::Stopword.filter(words, language: language)
       if enable_stemmer
-        words = TokenFilter::Stemmer.filter(words, language)
+        words = TokenFilter::Stemmer.filter(words, language: language)
       end
-      words = TokenFilter::Stopword.filter(words, language)
 
       d = Hash.new(0)
       words.each do |word|

--- a/lib/classifier-reborn/extensions/hasher.rb
+++ b/lib/classifier-reborn/extensions/hasher.rb
@@ -15,7 +15,7 @@ module ClassifierReborn
 
     # Return a Hash of strings => ints. Each word in the string is stemmed,
     # interned, and indexes to its frequency in the document.
-    def word_hash(str, language = 'en', enable_stemmer = true, clean: false,
+    def word_hash(str, language = 'en', enable_stemmer = true,
                   tokenizer: Tokenizer::Whitespace,
                   token_filters: [TokenFilter::Stopword])
       if token_filters.include?(TokenFilter::Stemmer)
@@ -27,7 +27,7 @@ module ClassifierReborn
       else
         token_filters << TokenFilter::Stemmer if enable_stemmer
       end
-      words = tokenizer.tokenize(str, clean: clean)
+      words = tokenizer.tokenize(str)
       token_filters.each do |token_filter|
         words = token_filter.filter(words, language: language)
       end

--- a/lib/classifier-reborn/extensions/token_filter/stemmer.rb
+++ b/lib/classifier-reborn/extensions/token_filter/stemmer.rb
@@ -5,6 +5,7 @@
 
 module ClassifierReborn
   module TokenFilter
+    # This filter converts given tokens to their stemmed versions in the language.
     module Stemmer
       module_function
 

--- a/lib/classifier-reborn/extensions/token_filter/stemmer.rb
+++ b/lib/classifier-reborn/extensions/token_filter/stemmer.rb
@@ -1,0 +1,22 @@
+# encoding: utf-8
+# Author::    Lucas Carlson  (mailto:lucas@rufy.com)
+# Copyright:: Copyright (c) 2005 Lucas Carlson
+# License::   LGPL
+
+module ClassifierReborn
+  module TokenFilter
+    module Stemmer
+      module_function
+
+      def filter(tokens, language = 'en')
+        tokens.collect do |token|
+          if token.stemmable?
+            token.stem
+          else
+            token
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/classifier-reborn/extensions/token_filter/stemmer.rb
+++ b/lib/classifier-reborn/extensions/token_filter/stemmer.rb
@@ -8,7 +8,7 @@ module ClassifierReborn
     module Stemmer
       module_function
 
-      def filter(tokens, language = 'en')
+      def filter(tokens, language: 'en')
         tokens.collect do |token|
           if token.stemmable?
             token.stem

--- a/lib/classifier-reborn/extensions/token_filter/stemmer.rb
+++ b/lib/classifier-reborn/extensions/token_filter/stemmer.rb
@@ -5,11 +5,11 @@
 
 module ClassifierReborn
   module TokenFilter
-    # This filter converts given tokens to their stemmed versions in the language.
+    # This filter converts given tokens to their stemmed versions.
     module Stemmer
       module_function
 
-      def filter(tokens, language: 'en')
+      def filter(tokens)
         tokens.collect do |token|
           if token.stemmable?
             token.stem

--- a/lib/classifier-reborn/extensions/token_filter/stemmer.rb
+++ b/lib/classifier-reborn/extensions/token_filter/stemmer.rb
@@ -9,7 +9,7 @@ module ClassifierReborn
     module Stemmer
       module_function
 
-      def filter(tokens)
+      def call(tokens)
         tokens.collect do |token|
           if token.stemmable?
             token.stem

--- a/lib/classifier-reborn/extensions/token_filter/stopword.rb
+++ b/lib/classifier-reborn/extensions/token_filter/stopword.rb
@@ -12,7 +12,7 @@ module ClassifierReborn
 
       module_function
 
-      def filter(tokens)
+      def call(tokens)
         tokens.reject do |token|
           token.maybe_stopword? &&
             (token.length <= 2 || STOPWORDS[@language].include?(token))

--- a/lib/classifier-reborn/extensions/token_filter/stopword.rb
+++ b/lib/classifier-reborn/extensions/token_filter/stopword.rb
@@ -10,7 +10,7 @@ module ClassifierReborn
 
       module_function
 
-      def filter(tokens, language = 'en')
+      def filter(tokens, language: 'en')
         tokens.reject do |token|
           token.maybe_stopword? &&
             (token.length <= 2 || STOPWORDS[language].include?(token))

--- a/lib/classifier-reborn/extensions/token_filter/stopword.rb
+++ b/lib/classifier-reborn/extensions/token_filter/stopword.rb
@@ -1,0 +1,39 @@
+# encoding: utf-8
+# Author::    Lucas Carlson  (mailto:lucas@rufy.com)
+# Copyright:: Copyright (c) 2005 Lucas Carlson
+# License::   LGPL
+
+module ClassifierReborn
+  module TokenFilter
+    module Stopword
+      STOPWORDS_PATH = [File.expand_path(File.dirname(__FILE__) + '/../../../../data/stopwords')]
+
+      module_function
+
+      def filter(words, language = 'en')
+        words.reject do |word|
+          word.length <= 2 || STOPWORDS[language].include?(word)
+        end
+      end
+
+      # Add custom path to a new stopword file created by user
+      def add_custom_stopword_path(path)
+        STOPWORDS_PATH.unshift(path)
+      end
+
+      # Create a lazily-loaded hash of stopword data
+      STOPWORDS = Hash.new do |hash, language|
+        hash[language] = []
+
+        STOPWORDS_PATH.each do |path|
+          if File.exist?(File.join(path, language))
+            hash[language] = Set.new File.read(File.join(path, language.to_s)).force_encoding("utf-8").split
+            break
+          end
+        end
+
+        hash[language]
+      end
+    end
+  end
+end

--- a/lib/classifier-reborn/extensions/token_filter/stopword.rb
+++ b/lib/classifier-reborn/extensions/token_filter/stopword.rb
@@ -10,9 +10,10 @@ module ClassifierReborn
 
       module_function
 
-      def filter(words, language = 'en')
-        words.reject do |word|
-          word.length <= 2 || STOPWORDS[language].include?(word)
+      def filter(tokens, language = 'en')
+        tokens.reject do |token|
+          token.maybe_stopword? &&
+            (token.length <= 2 || STOPWORDS[language].include?(token))
         end
       end
 

--- a/lib/classifier-reborn/extensions/token_filter/stopword.rb
+++ b/lib/classifier-reborn/extensions/token_filter/stopword.rb
@@ -5,6 +5,7 @@
 
 module ClassifierReborn
   module TokenFilter
+    # This filter removes stopwords in the language, from given tokens.
     module Stopword
       STOPWORDS_PATH = [File.expand_path(File.dirname(__FILE__) + '/../../../../data/stopwords')]
 

--- a/lib/classifier-reborn/extensions/token_filter/stopword.rb
+++ b/lib/classifier-reborn/extensions/token_filter/stopword.rb
@@ -8,13 +8,14 @@ module ClassifierReborn
     # This filter removes stopwords in the language, from given tokens.
     module Stopword
       STOPWORDS_PATH = [File.expand_path(File.dirname(__FILE__) + '/../../../../data/stopwords')]
+      @language = 'en'
 
       module_function
 
-      def filter(tokens, language: 'en')
+      def filter(tokens)
         tokens.reject do |token|
           token.maybe_stopword? &&
-            (token.length <= 2 || STOPWORDS[language].include?(token))
+            (token.length <= 2 || STOPWORDS[@language].include?(token))
         end
       end
 
@@ -35,6 +36,11 @@ module ClassifierReborn
         end
 
         hash[language]
+      end
+
+      # Changes the language of stopwords
+      def language=(language)
+        @language = language
       end
     end
   end

--- a/lib/classifier-reborn/extensions/token_filter/symbol.rb
+++ b/lib/classifier-reborn/extensions/token_filter/symbol.rb
@@ -1,0 +1,19 @@
+# encoding: utf-8
+# Author::    Lucas Carlson  (mailto:lucas@rufy.com)
+# Copyright:: Copyright (c) 2005 Lucas Carlson
+# License::   LGPL
+
+module ClassifierReborn
+  module TokenFilter
+    # This filter removes symbol-only terms, from given tokens.
+    module Symbol
+      module_function
+
+      def filter(tokens, language: 'en')
+        tokens.reject do |token|
+          /[^\s\p{WORD}]/ === token
+        end
+      end
+    end
+  end
+end

--- a/lib/classifier-reborn/extensions/token_filter/symbol.rb
+++ b/lib/classifier-reborn/extensions/token_filter/symbol.rb
@@ -9,7 +9,7 @@ module ClassifierReborn
     module Symbol
       module_function
 
-      def filter(tokens, language: 'en')
+      def filter(tokens)
         tokens.reject do |token|
           /[^\s\p{WORD}]/ === token
         end

--- a/lib/classifier-reborn/extensions/token_filter/symbol.rb
+++ b/lib/classifier-reborn/extensions/token_filter/symbol.rb
@@ -9,7 +9,7 @@ module ClassifierReborn
     module Symbol
       module_function
 
-      def filter(tokens)
+      def call(tokens)
         tokens.reject do |token|
           /[^\s\p{WORD}]/ === token
         end

--- a/lib/classifier-reborn/extensions/tokenizer/token.rb
+++ b/lib/classifier-reborn/extensions/tokenizer/token.rb
@@ -6,6 +6,12 @@
 module ClassifierReborn
   module Tokenizer
     class Token < String
+      # The class can be created with one token string and extra attributes. E.g.,
+      #      t = ClassifierReborn::Tokenizer::Token.new 'Tokenize', stemmable: true, maybe_stopword: false
+      #
+      # Attributes available are:
+      #   stemmable:        true  Possibility that the token can be stemmed. This must be false for un-stemmable terms, otherwise this should be true.
+      #   maybe_stopword:   true  Possibility that the token is a stopword. This must be false for terms which never been stopword, otherwise this should be true.
       def initialize(string, stemmable: true, maybe_stopword: true)
         super(string)
         @stemmable = stemmable

--- a/lib/classifier-reborn/extensions/tokenizer/token.rb
+++ b/lib/classifier-reborn/extensions/tokenizer/token.rb
@@ -1,0 +1,29 @@
+# encoding: utf-8
+# Author::    Lucas Carlson  (mailto:lucas@rufy.com)
+# Copyright:: Copyright (c) 2005 Lucas Carlson
+# License::   LGPL
+
+module ClassifierReborn
+  module Tokenizer
+    class Token < String
+      def initialize(string, stemmable: true, maybe_stopword: true)
+        super(string)
+        @stemmable = stemmable
+        @maybe_stopword = maybe_stopword
+      end
+
+      def stemmable?
+        @stemmable
+      end
+
+      def maybe_stopword?
+        @maybe_stopword
+      end
+
+      def stem
+        stemmed = super
+        self.class.new(stemmed, stemmable: @stemmable, maybe_stopword: @maybe_stopword)
+      end
+    end
+  end
+end

--- a/lib/classifier-reborn/extensions/tokenizer/whitespace.rb
+++ b/lib/classifier-reborn/extensions/tokenizer/whitespace.rb
@@ -12,7 +12,7 @@ module ClassifierReborn
     module Whitespace
       module_function
 
-      def tokenize(str)
+      def call(str)
         tokens = str.gsub(/[^\p{WORD}\s]/, '').downcase.split.collect do |word|
           Token.new(word, stemmable: true, maybe_stopword: true)
         end

--- a/lib/classifier-reborn/extensions/tokenizer/whitespace.rb
+++ b/lib/classifier-reborn/extensions/tokenizer/whitespace.rb
@@ -12,16 +12,14 @@ module ClassifierReborn
     module Whitespace
       module_function
 
-      def tokenize(str, clean: false)
+      def tokenize(str)
         tokens = str.gsub(/[^\p{WORD}\s]/, '').downcase.split.collect do |word|
           Token.new(word, stemmable: true, maybe_stopword: true)
         end
-        unless clean
-          symbol_tokens = str.scan(/[^\s\p{WORD}]/).collect do |word|
-            Token.new(word, stemmable: false, maybe_stopword: false)
-          end
-          tokens += symbol_tokens
+        symbol_tokens = str.scan(/[^\s\p{WORD}]/).collect do |word|
+          Token.new(word, stemmable: false, maybe_stopword: false)
         end
+        tokens += symbol_tokens
         tokens
       end
     end

--- a/lib/classifier-reborn/extensions/tokenizer/whitespace.rb
+++ b/lib/classifier-reborn/extensions/tokenizer/whitespace.rb
@@ -15,10 +15,10 @@ module ClassifierReborn
           Token.new(word, stemmable: true, maybe_stopword: true)
         end
         unless clean
-        symbol_tokens = str.scan(/[^\s\p{WORD}]/).collect do |word|
-          Token.new(word, stemmable: false, maybe_stopword: false)
-        end
-        word_tokens += symbol_tokens
+          symbol_tokens = str.scan(/[^\s\p{WORD}]/).collect do |word|
+            Token.new(word, stemmable: false, maybe_stopword: false)
+          end
+          word_tokens += symbol_tokens
         end
         word_tokens
       end

--- a/lib/classifier-reborn/extensions/tokenizer/whitespace.rb
+++ b/lib/classifier-reborn/extensions/tokenizer/whitespace.rb
@@ -7,6 +7,8 @@ require_relative 'token'
 
 module ClassifierReborn
   module Tokenizer
+    # This tokenizes given input as white-space separated terms.
+    # It mainly aims to tokenize sentences written with a space between words, like English, French, and others.
     module Whitespace
       module_function
 

--- a/lib/classifier-reborn/extensions/tokenizer/whitespace.rb
+++ b/lib/classifier-reborn/extensions/tokenizer/whitespace.rb
@@ -14,14 +14,12 @@ module ClassifierReborn
         tokens = str.gsub(/[^\p{WORD}\s]/, '').downcase.split.collect do |word|
           Token.new(word, stemmable: true, maybe_stopword: true)
         end
-
         unless clean
           symbol_tokens = str.scan(/[^\s\p{WORD}]/).collect do |word|
             Token.new(word, stemmable: false, maybe_stopword: false)
           end
           tokens += symbol_tokens
         end
-
         tokens = TokenFilter::Stopword.filter(tokens, language: language)
         if enable_stemmer
           tokens = TokenFilter::Stemmer.filter(tokens, language: language)

--- a/lib/classifier-reborn/extensions/tokenizer/whitespace.rb
+++ b/lib/classifier-reborn/extensions/tokenizer/whitespace.rb
@@ -15,10 +15,10 @@ module ClassifierReborn
           Token.new(word, stemmable: true, maybe_stopword: true)
         end
         unless clean
-          symbol_tokens = str.scan(/[^\s\p{WORD}]/).collect do |word|
-            Token.new(word, stemmable: false, maybe_stopword: false)
-          end
-          tokens += symbol_tokens
+        symbol_tokens = str.scan(/[^\s\p{WORD}]/).collect do |word|
+          Token.new(word, stemmable: false, maybe_stopword: false)
+        end
+        tokens += symbol_tokens
         end
         tokens = TokenFilter::Stopword.filter(tokens, language: language)
         if enable_stemmer

--- a/lib/classifier-reborn/extensions/tokenizer/whitespace.rb
+++ b/lib/classifier-reborn/extensions/tokenizer/whitespace.rb
@@ -15,10 +15,10 @@ module ClassifierReborn
           Token.new(word, stemmable: true, maybe_stopword: true)
         end
         unless clean
-        symbol_tokens = str.scan(/[^\s\p{WORD}]/).collect do |word|
-          Token.new(word, stemmable: false, maybe_stopword: false)
-        end
-        tokens += symbol_tokens
+          symbol_tokens = str.scan(/[^\s\p{WORD}]/).collect do |word|
+            Token.new(word, stemmable: false, maybe_stopword: false)
+          end
+          tokens += symbol_tokens
         end
         tokens = TokenFilter::Stopword.filter(tokens, language: language)
         if enable_stemmer

--- a/lib/classifier-reborn/extensions/tokenizer/whitespace.rb
+++ b/lib/classifier-reborn/extensions/tokenizer/whitespace.rb
@@ -10,17 +10,21 @@ module ClassifierReborn
     module Whitespace
       module_function
 
-      def tokenize(str, clean: false)
-        word_tokens = str.gsub(/[^\p{WORD}\s]/, '').downcase.split.collect do |word|
+      def tokenize(str, language: 'en', enable_stemmer: true, clean: false)
+        tokens = str.gsub(/[^\p{WORD}\s]/, '').downcase.split.collect do |word|
           Token.new(word, stemmable: true, maybe_stopword: true)
         end
         unless clean
         symbol_tokens = str.scan(/[^\s\p{WORD}]/).collect do |word|
           Token.new(word, stemmable: false, maybe_stopword: false)
         end
-        word_tokens += symbol_tokens
+        tokens += symbol_tokens
         end
-        word_tokens
+        tokens = TokenFilter::Stopword.filter(tokens, language: language)
+        if enable_stemmer
+          tokens = TokenFilter::Stemmer.filter(tokens, language: language)
+        end
+        tokens
       end
     end
   end

--- a/lib/classifier-reborn/extensions/tokenizer/whitespace.rb
+++ b/lib/classifier-reborn/extensions/tokenizer/whitespace.rb
@@ -3,13 +3,21 @@
 # Copyright:: Copyright (c) 2005 Lucas Carlson
 # License::   LGPL
 
+require_relative 'token'
+
 module ClassifierReborn
   module Tokenizer
     module Whitespace
       module_function
 
       def tokenize(str)
-        str.gsub(/[^\p{WORD}\s]/, '').downcase.split
+        word_tokens = str.gsub(/[^\p{WORD}\s]/, '').downcase.split.collect do |word|
+          Token.new(word, stemmable: true, maybe_stopword: true)
+        end
+        symbol_tokens = str.scan(/[^\s\p{WORD}]/).collect do |word|
+          Token.new(word, stemmable: false, maybe_stopword: false)
+        end
+        word_tokens + symbol_tokens
       end
     end
   end

--- a/lib/classifier-reborn/extensions/tokenizer/whitespace.rb
+++ b/lib/classifier-reborn/extensions/tokenizer/whitespace.rb
@@ -10,21 +10,17 @@ module ClassifierReborn
     module Whitespace
       module_function
 
-      def tokenize(str, language: 'en', enable_stemmer: true, clean: false)
-        tokens = str.gsub(/[^\p{WORD}\s]/, '').downcase.split.collect do |word|
+      def tokenize(str, clean: false)
+        word_tokens = str.gsub(/[^\p{WORD}\s]/, '').downcase.split.collect do |word|
           Token.new(word, stemmable: true, maybe_stopword: true)
         end
         unless clean
         symbol_tokens = str.scan(/[^\s\p{WORD}]/).collect do |word|
           Token.new(word, stemmable: false, maybe_stopword: false)
         end
-        tokens += symbol_tokens
+        word_tokens += symbol_tokens
         end
-        tokens = TokenFilter::Stopword.filter(tokens, language: language)
-        if enable_stemmer
-          tokens = TokenFilter::Stemmer.filter(tokens, language: language)
-        end
-        tokens
+        word_tokens
       end
     end
   end

--- a/lib/classifier-reborn/extensions/tokenizer/whitespace.rb
+++ b/lib/classifier-reborn/extensions/tokenizer/whitespace.rb
@@ -14,12 +14,14 @@ module ClassifierReborn
         tokens = str.gsub(/[^\p{WORD}\s]/, '').downcase.split.collect do |word|
           Token.new(word, stemmable: true, maybe_stopword: true)
         end
+
         unless clean
           symbol_tokens = str.scan(/[^\s\p{WORD}]/).collect do |word|
             Token.new(word, stemmable: false, maybe_stopword: false)
           end
           tokens += symbol_tokens
         end
+
         tokens = TokenFilter::Stopword.filter(tokens, language: language)
         if enable_stemmer
           tokens = TokenFilter::Stemmer.filter(tokens, language: language)

--- a/lib/classifier-reborn/extensions/tokenizer/whitespace.rb
+++ b/lib/classifier-reborn/extensions/tokenizer/whitespace.rb
@@ -1,0 +1,16 @@
+# encoding: utf-8
+# Author::    Lucas Carlson  (mailto:lucas@rufy.com)
+# Copyright:: Copyright (c) 2005 Lucas Carlson
+# License::   LGPL
+
+module ClassifierReborn
+  module Tokenizer
+    module Whitespace
+      module_function
+
+      def tokenize(str)
+        str.gsub(/[^\p{WORD}\s]/, '').downcase.split
+      end
+    end
+  end
+end

--- a/lib/classifier-reborn/extensions/tokenizer/whitespace.rb
+++ b/lib/classifier-reborn/extensions/tokenizer/whitespace.rb
@@ -11,16 +11,16 @@ module ClassifierReborn
       module_function
 
       def tokenize(str, clean: false)
-        word_tokens = str.gsub(/[^\p{WORD}\s]/, '').downcase.split.collect do |word|
+        tokens = str.gsub(/[^\p{WORD}\s]/, '').downcase.split.collect do |word|
           Token.new(word, stemmable: true, maybe_stopword: true)
         end
         unless clean
           symbol_tokens = str.scan(/[^\s\p{WORD}]/).collect do |word|
             Token.new(word, stemmable: false, maybe_stopword: false)
           end
-          word_tokens += symbol_tokens
+          tokens += symbol_tokens
         end
-        word_tokens
+        tokens
       end
     end
   end

--- a/lib/classifier-reborn/extensions/tokenizer/whitespace.rb
+++ b/lib/classifier-reborn/extensions/tokenizer/whitespace.rb
@@ -10,14 +10,17 @@ module ClassifierReborn
     module Whitespace
       module_function
 
-      def tokenize(str)
+      def tokenize(str, clean: false)
         word_tokens = str.gsub(/[^\p{WORD}\s]/, '').downcase.split.collect do |word|
           Token.new(word, stemmable: true, maybe_stopword: true)
         end
+        unless clean
         symbol_tokens = str.scan(/[^\s\p{WORD}]/).collect do |word|
           Token.new(word, stemmable: false, maybe_stopword: false)
         end
-        word_tokens + symbol_tokens
+        word_tokens += symbol_tokens
+        end
+        word_tokens
       end
     end
   end

--- a/lib/classifier-reborn/lsi.rb
+++ b/lib/classifier-reborn/lsi.rb
@@ -19,7 +19,7 @@ require_relative 'lsi/content_node'
 require_relative 'lsi/cached_content_node'
 require_relative 'lsi/summarizer'
 require_relative 'extensions/token_filter/stopword'
-require_relative 'extensions/token_filter/stemmer'
+require_relative 'extensions/token_filter/symbol'
 
 module ClassifierReborn
   # This class implements a Latent Semantic Indexer, which can search, classify and cluster

--- a/lib/classifier-reborn/lsi.rb
+++ b/lib/classifier-reborn/lsi.rb
@@ -46,6 +46,7 @@ module ClassifierReborn
         TokenFilter::Stopword,
         TokenFilter::Symbol,
       ]
+      TokenFilter::Stopword.language = @language
       extend CachedContentNode::InstanceMethods if @cache_node_vectors = options[:cache_node_vectors]
     end
 
@@ -70,7 +71,7 @@ module ClassifierReborn
     #   lsi.add_item ar, *ar.categories { |x| ar.content }
     #
     def add_item(item, *categories, &block)
-      clean_word_hash = Hasher.word_hash((block ? block.call(item) : item.to_s), @language,
+      clean_word_hash = Hasher.word_hash((block ? block.call(item) : item.to_s),
                                          token_filters: @token_filters)
       if clean_word_hash.empty?
         puts "Input: '#{item}' is entirely stopwords or words with 2 or fewer characters. Classifier-Reborn cannot handle this document properly."
@@ -329,7 +330,7 @@ module ClassifierReborn
       if @items[item]
         return @items[item]
       else
-        clean_word_hash = Hasher.word_hash((block ? block.call(item) : item.to_s), @language,
+        clean_word_hash = Hasher.word_hash((block ? block.call(item) : item.to_s),
                                            token_filters: @token_filters)
 
         content_node = ContentNode.new(clean_word_hash, &block) # make the node and extract the data

--- a/lib/classifier-reborn/lsi.rb
+++ b/lib/classifier-reborn/lsi.rb
@@ -64,7 +64,7 @@ module ClassifierReborn
     #   lsi.add_item ar, *ar.categories { |x| ar.content }
     #
     def add_item(item, *categories, &block)
-      clean_word_hash = Hasher.clean_word_hash((block ? block.call(item) : item.to_s), @language)
+      clean_word_hash = Hasher.word_hash((block ? block.call(item) : item.to_s), @language, clean: true)
       if clean_word_hash.empty?
         puts "Input: '#{item}' is entirely stopwords or words with 2 or fewer characters. Classifier-Reborn cannot handle this document properly."
       else
@@ -322,7 +322,7 @@ module ClassifierReborn
       if @items[item]
         return @items[item]
       else
-        clean_word_hash = Hasher.clean_word_hash((block ? block.call(item) : item.to_s), @language)
+        clean_word_hash = Hasher.word_hash((block ? block.call(item) : item.to_s), @language, clean: true)
 
         content_node = ContentNode.new(clean_word_hash, &block) # make the node and extract the data
 

--- a/test/bayes/bayesian_memory_test.rb
+++ b/test/bayes/bayesian_memory_test.rb
@@ -9,10 +9,10 @@ class BayesianMemoryTest < Minitest::Test
   def setup
     @alternate_backend = ClassifierReborn::BayesMemoryBackend.new
     @classifier = ClassifierReborn::Bayes.new 'Interesting', 'Uninteresting'
-    @old_stopwords = Hasher::STOPWORDS['en']
+    @old_stopwords = TokenFilter::Stopword::STOPWORDS['en']
   end
 
   def teardown
-    Hasher::STOPWORDS['en'] = @old_stopwords
+    TokenFilter::Stopword::STOPWORDS['en'] = @old_stopwords
   end
 end

--- a/test/bayes/bayesian_redis_test.rb
+++ b/test/bayes/bayesian_redis_test.rb
@@ -8,7 +8,7 @@ class BayesianRedisTest < Minitest::Test
 
   def setup
     begin
-      @old_stopwords = Hasher::STOPWORDS['en']
+      @old_stopwords = TokenFilter::Stopword::STOPWORDS['en']
       @backend = ClassifierReborn::BayesRedisBackend.new
       @backend.instance_variable_get(:@redis).config(:set, "save", "")
       @alternate_backend = ClassifierReborn::BayesRedisBackend.new(db: 1)
@@ -19,7 +19,7 @@ class BayesianRedisTest < Minitest::Test
   end
 
   def teardown
-    Hasher::STOPWORDS['en'] = @old_stopwords
+    TokenFilter::Stopword::STOPWORDS['en'] = @old_stopwords
     if defined? @backend
       @backend.reset
       @alternate_backend.reset

--- a/test/extensions/hasher_test.rb
+++ b/test/extensions/hasher_test.rb
@@ -11,55 +11,6 @@ class HasherTest < Minitest::Test
     assert_equal hash, Hasher.word_hash("here are some good words of test's. I hope you love them!")
   end
 
-  def test_clean_word_hash
-    hash = { good: 1, word: 1, hope: 1, love: 1, them: 1, test: 1 }
-    assert_equal hash, Hasher.clean_word_hash("here are some good words of test's. I hope you love them!")
-  end
-
-  def test_clean_word_hash_without_stemming
-    hash = { good: 1, words: 1, hope: 1, love: 1, them: 1, tests: 1 }
-    assert_equal hash, Hasher.clean_word_hash("here are some good words of test's. I hope you love them!", 'en', false)
-  end
-
-  def test_default_stopwords
-    refute_empty TokenFilter::Stopword::STOPWORDS['en']
-    refute_empty TokenFilter::Stopword::STOPWORDS['fr']
-    assert_empty TokenFilter::Stopword::STOPWORDS['gibberish']
-  end
-
-  def test_loads_custom_stopwords
-    default_english_stopwords = TokenFilter::Stopword::STOPWORDS['en']
-
-    # Remove the english stopwords
-    TokenFilter::Stopword::STOPWORDS.delete('en')
-
-    # Add a custom stopwords path
-    TokenFilter::Stopword::STOPWORDS_PATH.unshift File.expand_path(File.dirname(__FILE__) + '/../data/stopwords')
-
-    custom_english_stopwords = TokenFilter::Stopword::STOPWORDS['en']
-
-    refute_equal default_english_stopwords, custom_english_stopwords
-  end
-
-  def test_add_custom_stopword_path
-    # Create stopword tempfile in current directory
-    temp_stopwords = Tempfile.new('xy', "#{File.dirname(__FILE__) + "/"}")
-
-    # Add some stopwords to tempfile
-    temp_stopwords << "this words fun"
-    temp_stopwords.close
-
-    # Get path of tempfile
-    temp_stopwords_path = File.dirname(temp_stopwords)
-
-    # Get tempfile name.
-    temp_stopwords_name = File.basename(temp_stopwords.path)
-
-    TokenFilter::Stopword.add_custom_stopword_path(temp_stopwords_path)
-    hash = { list: 1, cool: 1 }
-    assert_equal hash, Hasher.clean_word_hash("this is a list of cool words!", temp_stopwords_name)
-  end
-
   def teardown
     TokenFilter::Stopword::STOPWORDS.clear
     TokenFilter::Stopword::STOPWORDS_PATH.clear.concat @original_stopwords_path

--- a/test/extensions/hasher_test.rb
+++ b/test/extensions/hasher_test.rb
@@ -11,6 +11,34 @@ class HasherTest < Minitest::Test
     assert_equal hash, Hasher.word_hash("here are some good words of test's. I hope you love them!")
   end
 
+  module BigramTokenizer
+    module_function
+    def tokenize(str)
+      str.each_char
+         .each_cons(2)
+         .map do |chars| ::ClassifierReborn::Tokenizer::Token.new(chars.join) end
+    end
+  end
+
+  def test_custom_tokenizer
+    hash = { te: 1, er: 1, rm: 1 }
+    assert_equal hash, Hasher.word_hash("term", tokenizer: BigramTokenizer, token_filters: [])
+  end
+
+  module CatFilter
+    module_function
+    def filter(tokens)
+      tokens.reject do |token|
+        /\Acat\z/i === token
+      end
+    end
+  end
+
+  def test_custom_token_filters
+    hash = { dog: 1 }
+    assert_equal hash, Hasher.word_hash("cat dog", token_filters: [CatFilter])
+  end
+
   def teardown
     TokenFilter::Stopword::STOPWORDS.clear
     TokenFilter::Stopword::STOPWORDS_PATH.clear.concat @original_stopwords_path

--- a/test/extensions/hasher_test.rb
+++ b/test/extensions/hasher_test.rb
@@ -13,30 +13,50 @@ class HasherTest < Minitest::Test
 
   module BigramTokenizer
     module_function
-    def tokenize(str)
+    def call(str)
       str.each_char
          .each_cons(2)
          .map do |chars| ::ClassifierReborn::Tokenizer::Token.new(chars.join) end
     end
   end
 
-  def test_custom_tokenizer
+  def test_custom_tokenizer_module
     hash = { te: 1, er: 1, rm: 1 }
     assert_equal hash, Hasher.word_hash("term", tokenizer: BigramTokenizer, token_filters: [])
   end
 
+  def test_custom_tokenizer_lambda
+    hash = { te: 1, er: 1, rm: 1 }
+    bigram_tokenizer = lambda do |str|
+      str.each_char
+         .each_cons(2)
+         .map do |chars| ::ClassifierReborn::Tokenizer::Token.new(chars.join) end
+    end
+    assert_equal hash, Hasher.word_hash("term", tokenizer: bigram_tokenizer, token_filters: [])
+  end
+
   module CatFilter
     module_function
-    def filter(tokens)
+    def call(tokens)
       tokens.reject do |token|
         /\Acat\z/i === token
       end
     end
   end
 
-  def test_custom_token_filters
+  def test_custom_token_filters_module
     hash = { dog: 1 }
     assert_equal hash, Hasher.word_hash("cat dog", token_filters: [CatFilter])
+  end
+
+  def test_custom_token_filters_lambda
+    hash = { dog: 1 }
+    cat_filter = lambda do |tokens|
+      tokens.reject do |token|
+        /\Acat\z/i === token
+      end
+    end
+    assert_equal hash, Hasher.word_hash("cat dog", token_filters: [cat_filter])
   end
 
   def teardown

--- a/test/extensions/hasher_test.rb
+++ b/test/extensions/hasher_test.rb
@@ -25,12 +25,31 @@ class HasherTest < Minitest::Test
     assert_equal hash, Hasher.word_hash("term", tokenizer: BigramTokenizer, token_filters: [])
   end
 
+  class BigramTokenizerClass
+    def call(str)
+      BigramTokenizer.call(str)
+    end
+
+    def self.call(str)
+      BigramTokenizer.call(str)
+    end
+  end
+
+  def test_custom_tokenizer_class
+    hash = { te: 1, er: 1, rm: 1 }
+    assert_equal hash, Hasher.word_hash("term", tokenizer: BigramTokenizerClass, token_filters: [])
+  end
+
+  def test_custom_tokenizer_instance
+    hash = { te: 1, er: 1, rm: 1 }
+    bigram_tokenizer = BigramTokenizerClass.new
+    assert_equal hash, Hasher.word_hash("term", tokenizer: bigram_tokenizer, token_filters: [])
+  end
+
   def test_custom_tokenizer_lambda
     hash = { te: 1, er: 1, rm: 1 }
     bigram_tokenizer = lambda do |str|
-      str.each_char
-         .each_cons(2)
-         .map do |chars| ::ClassifierReborn::Tokenizer::Token.new(chars.join) end
+      BigramTokenizer.call(str)
     end
     assert_equal hash, Hasher.word_hash("term", tokenizer: bigram_tokenizer, token_filters: [])
   end
@@ -49,12 +68,31 @@ class HasherTest < Minitest::Test
     assert_equal hash, Hasher.word_hash("cat dog", token_filters: [CatFilter])
   end
 
+  class CatFilterClass
+    def call(tokens)
+      CatFilter.call(tokens)
+    end
+
+    def self.call(tokens)
+      CatFilter.call(tokens)
+    end
+  end
+
+  def test_custom_token_filters_class
+    hash = { dog: 1 }
+    assert_equal hash, Hasher.word_hash("cat dog", token_filters: [CatFilterClass])
+  end
+
+  def test_custom_token_filters_instance
+    hash = { dog: 1 }
+    cat_filter = CatFilterClass.new
+    assert_equal hash, Hasher.word_hash("cat dog", token_filters: [cat_filter])
+  end
+
   def test_custom_token_filters_lambda
     hash = { dog: 1 }
     cat_filter = lambda do |tokens|
-      tokens.reject do |token|
-        /\Acat\z/i === token
-      end
+      CatFilter.call(tokens)
     end
     assert_equal hash, Hasher.word_hash("cat dog", token_filters: [cat_filter])
   end

--- a/test/extensions/hasher_test.rb
+++ b/test/extensions/hasher_test.rb
@@ -3,7 +3,7 @@ require 'tempfile'
 
 class HasherTest < Minitest::Test
   def setup
-    @original_stopwords_path = Hasher::STOPWORDS_PATH.dup
+    @original_stopwords_path = TokenFilter::Stopword::STOPWORDS_PATH.dup
   end
 
   def test_word_hash
@@ -22,21 +22,21 @@ class HasherTest < Minitest::Test
   end
 
   def test_default_stopwords
-    refute_empty Hasher::STOPWORDS['en']
-    refute_empty Hasher::STOPWORDS['fr']
-    assert_empty Hasher::STOPWORDS['gibberish']
+    refute_empty TokenFilter::Stopword::STOPWORDS['en']
+    refute_empty TokenFilter::Stopword::STOPWORDS['fr']
+    assert_empty TokenFilter::Stopword::STOPWORDS['gibberish']
   end
 
   def test_loads_custom_stopwords
-    default_english_stopwords = Hasher::STOPWORDS['en']
+    default_english_stopwords = TokenFilter::Stopword::STOPWORDS['en']
 
     # Remove the english stopwords
-    Hasher::STOPWORDS.delete('en')
+    TokenFilter::Stopword::STOPWORDS.delete('en')
 
     # Add a custom stopwords path
-    Hasher::STOPWORDS_PATH.unshift File.expand_path(File.dirname(__FILE__) + '/../data/stopwords')
+    TokenFilter::Stopword::STOPWORDS_PATH.unshift File.expand_path(File.dirname(__FILE__) + '/../data/stopwords')
 
-    custom_english_stopwords = Hasher::STOPWORDS['en']
+    custom_english_stopwords = TokenFilter::Stopword::STOPWORDS['en']
 
     refute_equal default_english_stopwords, custom_english_stopwords
   end
@@ -55,13 +55,13 @@ class HasherTest < Minitest::Test
     # Get tempfile name.
     temp_stopwords_name = File.basename(temp_stopwords.path)
 
-    Hasher.add_custom_stopword_path(temp_stopwords_path)
+    TokenFilter::Stopword.add_custom_stopword_path(temp_stopwords_path)
     hash = { list: 1, cool: 1 }
     assert_equal hash, Hasher.clean_word_hash("this is a list of cool words!", temp_stopwords_name)
   end
 
   def teardown
-    Hasher::STOPWORDS.clear
-    Hasher::STOPWORDS_PATH.clear.concat @original_stopwords_path
+    TokenFilter::Stopword::STOPWORDS.clear
+    TokenFilter::Stopword::STOPWORDS_PATH.clear.concat @original_stopwords_path
   end
 end

--- a/test/extensions/token_filter/stemmer_test.rb
+++ b/test/extensions/token_filter/stemmer_test.rb
@@ -6,7 +6,7 @@ class TokenFilterStemmerTest < Minitest::Test
     words = %w(numbers words).collect do |word|
       Tokenizer::Token.new(word, stemmable: true)
     end
-    words = TokenFilter::Stemmer.filter(words)
+    words = TokenFilter::Stemmer.call(words)
     assert_equal %w(number word), words
   end
 end

--- a/test/extensions/token_filter/stemmer_test.rb
+++ b/test/extensions/token_filter/stemmer_test.rb
@@ -1,0 +1,12 @@
+require_relative '../../test_helper'
+require 'tempfile'
+
+class TokenFilterStemmerTest < Minitest::Test
+  def test_stemming
+    words = %w(numbers words).collect do |word|
+      Tokenizer::Token.new(word, stemmable: true)
+    end
+    words = TokenFilter::Stemmer.filter(words)
+    assert_equal %w(number word), words
+  end
+end

--- a/test/extensions/token_filter/stopword_test.rb
+++ b/test/extensions/token_filter/stopword_test.rb
@@ -41,9 +41,9 @@ class TokenFilterStopwordTest < Minitest::Test
     temp_stopwords_name = File.basename(temp_stopwords.path)
 
     TokenFilter::Stopword.add_custom_stopword_path(temp_stopwords_path)
-    words = Tokenizer::Whitespace.tokenize("this is a list of cool words!")
+    words = Tokenizer::Whitespace.call("this is a list of cool words!")
     TokenFilter::Stopword.language = temp_stopwords_name
-    words = TokenFilter::Stopword.filter(words)
+    words = TokenFilter::Stopword.call(words)
     assert_equal %w(list cool !), words
   end
 

--- a/test/extensions/token_filter/stopword_test.rb
+++ b/test/extensions/token_filter/stopword_test.rb
@@ -1,0 +1,53 @@
+require_relative '../../test_helper'
+require 'tempfile'
+
+class TokenFilterStopwordTest < Minitest::Test
+  def setup
+    @original_stopwords_path = TokenFilter::Stopword::STOPWORDS_PATH.dup
+  end
+
+  def test_default_stopwords
+    refute_empty TokenFilter::Stopword::STOPWORDS['en']
+    refute_empty TokenFilter::Stopword::STOPWORDS['fr']
+    assert_empty TokenFilter::Stopword::STOPWORDS['gibberish']
+  end
+
+  def test_loads_custom_stopwords
+    default_english_stopwords = TokenFilter::Stopword::STOPWORDS['en']
+
+    # Remove the english stopwords
+    TokenFilter::Stopword::STOPWORDS.delete('en')
+
+    # Add a custom stopwords path
+    TokenFilter::Stopword::STOPWORDS_PATH.unshift File.expand_path(File.dirname(__FILE__) + '/../../data/stopwords')
+
+    custom_english_stopwords = TokenFilter::Stopword::STOPWORDS['en']
+
+    refute_equal default_english_stopwords, custom_english_stopwords
+  end
+
+  def test_add_custom_stopword_path
+    # Create stopword tempfile in current directory
+    temp_stopwords = Tempfile.new('xy', "#{File.dirname(__FILE__) + "/"}")
+
+    # Add some stopwords to tempfile
+    temp_stopwords << "this words fun"
+    temp_stopwords.close
+
+    # Get path of tempfile
+    temp_stopwords_path = File.dirname(temp_stopwords)
+
+    # Get tempfile name.
+    temp_stopwords_name = File.basename(temp_stopwords.path)
+
+    TokenFilter::Stopword.add_custom_stopword_path(temp_stopwords_path)
+    words = Tokenizer::Whitespace.tokenize("this is a list of cool words!")
+    words = TokenFilter::Stopword.filter(words, temp_stopwords_name)
+    assert_equal %w(list cool !), words
+  end
+
+  def teardown
+    TokenFilter::Stopword::STOPWORDS.clear
+    TokenFilter::Stopword::STOPWORDS_PATH.clear.concat @original_stopwords_path
+  end
+end

--- a/test/extensions/token_filter/stopword_test.rb
+++ b/test/extensions/token_filter/stopword_test.rb
@@ -42,12 +42,14 @@ class TokenFilterStopwordTest < Minitest::Test
 
     TokenFilter::Stopword.add_custom_stopword_path(temp_stopwords_path)
     words = Tokenizer::Whitespace.tokenize("this is a list of cool words!")
-    words = TokenFilter::Stopword.filter(words, language: temp_stopwords_name)
+    TokenFilter::Stopword.language = temp_stopwords_name
+    words = TokenFilter::Stopword.filter(words)
     assert_equal %w(list cool !), words
   end
 
   def teardown
     TokenFilter::Stopword::STOPWORDS.clear
     TokenFilter::Stopword::STOPWORDS_PATH.clear.concat @original_stopwords_path
+    TokenFilter::Stopword.language = 'en'
   end
 end

--- a/test/extensions/token_filter/stopword_test.rb
+++ b/test/extensions/token_filter/stopword_test.rb
@@ -42,7 +42,7 @@ class TokenFilterStopwordTest < Minitest::Test
 
     TokenFilter::Stopword.add_custom_stopword_path(temp_stopwords_path)
     words = Tokenizer::Whitespace.tokenize("this is a list of cool words!")
-    words = TokenFilter::Stopword.filter(words, temp_stopwords_name)
+    words = TokenFilter::Stopword.filter(words, language: temp_stopwords_name)
     assert_equal %w(list cool !), words
   end
 

--- a/test/extensions/token_filter/symbol_test.rb
+++ b/test/extensions/token_filter/symbol_test.rb
@@ -6,7 +6,7 @@ class TokenFilterSymbolTest < Minitest::Test
     words = %w(term ! ?).collect do |word|
       Tokenizer::Token.new(word)
     end
-    words = TokenFilter::Symbol.filter(words)
+    words = TokenFilter::Symbol.call(words)
     assert_equal %w(term), words
   end
 end

--- a/test/extensions/token_filter/symbol_test.rb
+++ b/test/extensions/token_filter/symbol_test.rb
@@ -1,0 +1,12 @@
+require_relative '../../test_helper'
+require 'tempfile'
+
+class TokenFilterSymbolTest < Minitest::Test
+  def test_symbol
+    words = %w(term ! ?).collect do |word|
+      Tokenizer::Token.new(word)
+    end
+    words = TokenFilter::Symbol.filter(words)
+    assert_equal %w(term), words
+  end
+end

--- a/test/extensions/tokenizer/token_test.rb
+++ b/test/extensions/tokenizer/token_test.rb
@@ -1,0 +1,34 @@
+require_relative '../../test_helper'
+require 'tempfile'
+
+class TokenizerTokenTest < Minitest::Test
+  class StemmableTest < self
+    def test_stemmable
+      token = Tokenizer::Token.new("word", stemmable: true)
+      assert_equal "word", token
+      assert token.stemmable?
+    end
+
+    def test_not_stemmable
+      token = Tokenizer::Token.new("word", stemmable: false)
+      assert_equal "word", token
+      assert !token.stemmable?
+    end
+  end
+
+  class StemTest < self
+    def test_maybe_stopword
+      token = Tokenizer::Token.new("numbers", maybe_stopword: true)
+      stemmed = token.stem
+      assert_equal "number", stemmed
+      assert stemmed.maybe_stopword?
+    end
+
+    def test_not_stopword
+      token = Tokenizer::Token.new("do", maybe_stopword: false)
+      stemmed = token.stem
+      assert_equal "do", stemmed
+      assert !stemmed.maybe_stopword?
+    end
+  end
+end

--- a/test/extensions/tokenizer/whitespace_test.rb
+++ b/test/extensions/tokenizer/whitespace_test.rb
@@ -1,0 +1,15 @@
+require_relative '../../test_helper'
+require 'tempfile'
+
+class TokenizerWhitespaceTest < Minitest::Test
+  def test_tokenize
+    tokens = %w(here are some good words of tests i hope you love them ' . !)
+    stemmabilities = [true, true, true, true, true, true, true, true, true, true, true, true, false, false, false]
+    maybe_stopwords = [true, true, true, true, true, true, true, true, true, true, true, true, false, false, false]
+
+    actual_tokens = Tokenizer::Whitespace.tokenize("here are some good words of test's. I hope you love them!")
+    assert_equal tokens, actual_tokens
+    assert_equal stemmabilities, actual_tokens.collect(&:stemmable?)
+    assert_equal maybe_stopwords, actual_tokens.collect(&:maybe_stopword?)
+  end
+end

--- a/test/extensions/tokenizer/whitespace_test.rb
+++ b/test/extensions/tokenizer/whitespace_test.rb
@@ -7,7 +7,7 @@ class TokenizerWhitespaceTest < Minitest::Test
     stemmabilities = [true, true, true, true, true, true, true, true, true, true, true, true, false, false, false]
     maybe_stopwords = [true, true, true, true, true, true, true, true, true, true, true, true, false, false, false]
 
-    actual_tokens = Tokenizer::Whitespace.tokenize("here are some good words of test's. I hope you love them!")
+    actual_tokens = Tokenizer::Whitespace.call("here are some good words of test's. I hope you love them!")
     assert_equal tokens, actual_tokens
     assert_equal stemmabilities, actual_tokens.collect(&:stemmable?)
     assert_equal maybe_stopwords, actual_tokens.collect(&:maybe_stopword?)


### PR DESCRIPTION
Now I'm trying to separate tokenizing operations from the hasher, as the first step for #131. I introduced these new modules and classes:

 * `Tokenizer::Whitespace`
 * `Tokenizer::Token`
 * `TokenFilter::Stopword`
 * `TokenFilter::Stemmer`

For testability and flexibility, they are stayed separated for now. Next step, I'm planning to introduce some mechanism to switch the tokenizer and related modules.

How about this approach?