### PR TITLE
Fix invalid URI

### DIFF
--- a/classifier-reborn.gemspec
+++ b/classifier-reborn.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.summary          = 'A general classifier module to allow Bayesian and other types of classifications.'
   s.authors          = ['Lucas Carlson', 'Parker Moore', 'Chase Gilliam']
   s.email            = ['lucas@rufy.com', 'parkrmoore@gmail.com', 'chase.gilliam@gmail.com']
-  s.homepage         = 'www.classifier-reborn.com'
+  s.homepage         = 'http://www.classifier-reborn.com'
 
   all_files          = `git ls-files -z`.split("\x0")
   s.files            = all_files.grep(%r{^(bin|lib|data)/})


### PR DESCRIPTION
I saw an error when I tried to run test, as:

```
$ bundle exec rake test
/var/lib/gems/2.3.0/gems/bundler-1.15.1/lib/bundler/rubygems_integration.rb:64:in `rescue in validate': The gemspec at /home/piro/projects/classifier-reborn/classifier-reborn.gemspec is not valid. Please fix this gemspec. (Gem::InvalidSpecificationException)
The validation error was '"www.classifier-reborn.com" is not a URI'
	from /var/lib/gems/2.3.0/gems/bundler-1.15.1/lib/bundler/rubygems_integration.rb:60:in `validate'
	from /var/lib/gems/2.3.0/gems/bundler-1.15.1/lib/bundler/source/path.rb:154:in `validate_spec'
	from /var/lib/gems/2.3.0/gems/bundler-1.15.1/lib/bundler/source/path.rb:168:in `block in load_spec_files'
	from /var/lib/gems/2.3.0/gems/bundler-1.15.1/lib/bundler/source/path.rb:162:in `each'
	from /var/lib/gems/2.3.0/gems/bundler-1.15.1/lib/bundler/source/path.rb:162:in `load_spec_files'
	from /var/lib/gems/2.3.0/gems/bundler-1.15.1/lib/bundler/source/path.rb:97:in `local_specs'
	from /var/lib/gems/2.3.0/gems/bundler-1.15.1/lib/bundler/source/path.rb:105:in `specs'
	from /var/lib/gems/2.3.0/gems/bundler-1.15.1/lib/bundler/definition.rb:587:in `specs_for_source_changed?'
	from /var/lib/gems/2.3.0/gems/bundler-1.15.1/lib/bundler/definition.rb:572:in `specs_changed?'
	from /var/lib/gems/2.3.0/gems/bundler-1.15.1/lib/bundler/definition.rb:613:in `block in converge_paths'
	from /var/lib/gems/2.3.0/gems/bundler-1.15.1/lib/bundler/definition.rb:612:in `any?'
	from /var/lib/gems/2.3.0/gems/bundler-1.15.1/lib/bundler/definition.rb:612:in `converge_paths'
	from /var/lib/gems/2.3.0/gems/bundler-1.15.1/lib/bundler/definition.rb:108:in `initialize'
	from /var/lib/gems/2.3.0/gems/bundler-1.15.1/lib/bundler/dsl.rb:200:in `new'
	from /var/lib/gems/2.3.0/gems/bundler-1.15.1/lib/bundler/dsl.rb:200:in `to_definition'
	from /var/lib/gems/2.3.0/gems/bundler-1.15.1/lib/bundler/dsl.rb:12:in `evaluate'
	from /var/lib/gems/2.3.0/gems/bundler-1.15.1/lib/bundler/definition.rb:33:in `build'
	from /var/lib/gems/2.3.0/gems/bundler-1.15.1/lib/bundler.rb:129:in `definition'
	from /var/lib/gems/2.3.0/gems/bundler-1.15.1/lib/bundler.rb:95:in `setup'
	from /var/lib/gems/2.3.0/gems/bundler-1.15.1/lib/bundler/setup.rb:10:in `<top (required)>'
	from /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
```

This PR fixes the error for me.