### PR TITLE
Fix the corner cases

### DIFF
--- a/lib/classifier-reborn/extensions/vector.rb
+++ b/lib/classifier-reborn/extensions/vector.rb
@@ -31,7 +31,11 @@ class Matrix
         (1..qrot.row_size - 1).each do |col|
           next if row == col
 
-          h = Math.atan((2.0 * qrot[row, col]) / (qrot[row, row] - qrot[col, col])) / 2.0
+          if (2.0 * qrot[row, col]) == (qrot[row, row] - qrot[col, col])
+            h = Math.atan(1) / 2.0
+          else
+            h = Math.atan((2.0 * qrot[row, col]) / (qrot[row, row] - qrot[col, col])) / 2.0
+          end
           hcos = Math.cos(h)
           hsin = Math.sin(h)
           mzrot = Matrix.identity(qrot.row_size)

--- a/lib/classifier-reborn/extensions/vector.rb
+++ b/lib/classifier-reborn/extensions/vector.rb
@@ -31,7 +31,7 @@ class Matrix
         (1..qrot.row_size - 1).each do |col|
           next if row == col
 
-          h = Math.atan((2 * qrot[row, col]) / (qrot[row, row] - qrot[col, col])) / 2.0
+          h = Math.atan((2.0 * qrot[row, col]) / (qrot[row, row] - qrot[col, col])) / 2.0
           hcos = Math.cos(h)
           hsin = Math.sin(h)
           mzrot = Matrix.identity(qrot.row_size)

--- a/lib/classifier-reborn/extensions/zero_vector.rb
+++ b/lib/classifier-reborn/extensions/zero_vector.rb
@@ -1,0 +1,5 @@
+class Vector
+  def zero?
+    self.all? {|_| _ == 0}
+  end
+end

--- a/lib/classifier-reborn/lsi.rb
+++ b/lib/classifier-reborn/lsi.rb
@@ -143,7 +143,7 @@ module ClassifierReborn
         tdm = Matrix.rows(tda).trans
         ntdm = build_reduced_matrix(tdm, cutoff)
 
-        ntdm.column_size.times do |col|
+        ntdm.row_size.times do |col|
           doc_list[col].lsi_vector = ntdm.column(col) if doc_list[col]
           if ntdm.column(col).zero?
             doc_list[col].lsi_norm = ntdm.column(col) if doc_list[col]

--- a/lib/classifier-reborn/lsi.rb
+++ b/lib/classifier-reborn/lsi.rb
@@ -143,7 +143,7 @@ module ClassifierReborn
         tdm = Matrix.rows(tda).trans
         ntdm = build_reduced_matrix(tdm, cutoff)
 
-        ntdm.row_size.times do |col|
+        ntdm.column_size.times do |col|
           doc_list[col].lsi_vector = ntdm.column(col) if doc_list[col]
           if ntdm.column(col).zero?
             doc_list[col].lsi_norm = ntdm.column(col) if doc_list[col]

--- a/lib/classifier-reborn/lsi.rb
+++ b/lib/classifier-reborn/lsi.rb
@@ -12,6 +12,7 @@ begin
 rescue LoadError
   $GSL = false
   require_relative 'extensions/vector'
+  require_relative 'extensions/zero_vector'
 end
 
 require_relative 'lsi/word_list'
@@ -144,7 +145,11 @@ module ClassifierReborn
 
         ntdm.row_size.times do |col|
           doc_list[col].lsi_vector = ntdm.column(col) if doc_list[col]
-          doc_list[col].lsi_norm = ntdm.column(col).normalize if doc_list[col]
+          if ntdm.column(col).zero?
+            doc_list[col].lsi_norm = ntdm.column(col) if doc_list[col]
+          else
+            doc_list[col].lsi_norm = ntdm.column(col).normalize if doc_list[col]
+          end
         end
       end
 

--- a/test/extensions/matrix_test.rb
+++ b/test/extensions/matrix_test.rb
@@ -1,0 +1,6 @@
+class MatrixTest < Minitest::Test
+  def test_zero_division
+    matrix = Matrix[[1, 0], [0, 1]]
+    matrix.SV_decomp
+  end
+end

--- a/test/extensions/zero_vector_test.rb
+++ b/test/extensions/zero_vector_test.rb
@@ -1,0 +1,10 @@
+class ZeroVectorTest < Minitest::Test
+  def test_zero?
+    vec0 = Vector[]
+    vec1 = Vector[0]
+    vec10 = Vector.elements [0] * 10
+    assert vec0.zero?
+    assert vec1.zero?
+    assert vec10.zero?
+  end
+end

--- a/test/lsi/lsi_test.rb
+++ b/test/lsi/lsi_test.rb
@@ -30,6 +30,13 @@ class LSITest < Minitest::Test
     assert !lsi.needs_rebuild?
   end
 
+  def test_zero_vector_normalization
+    lsi = ClassifierReborn::LSI.new
+    lsi.add_item @str1[0...8], 'Dog'
+    lsi.add_item @str2, 'Dog'
+    lsi.add_item @str3, 'Cat'
+  end
+
   def test_basic_categorizing
     lsi = ClassifierReborn::LSI.new
     lsi.add_item @str2, 'Dog'

--- a/test/lsi/lsi_test.rb
+++ b/test/lsi/lsi_test.rb
@@ -31,10 +31,11 @@ class LSITest < Minitest::Test
   end
 
   def test_zero_vector_normalization
-    lsi = ClassifierReborn::LSI.new
+    lsi = ClassifierReborn::LSI.new auto_rebuild: false
     lsi.add_item @str1[0...8], 'Dog'
     lsi.add_item @str2, 'Dog'
     lsi.add_item @str3, 'Cat'
+    lsi.build_index(0.75)
   end
 
   def test_basic_categorizing


### PR DESCRIPTION
I've tried doing

- avoid zero division & zero vector normalization
- prevent an indeterminate form from being generated (by `0.0 / 0.0` )