### PR TITLE
Update references to the new documentation homepage

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -4,7 +4,7 @@
 [![Build Status](https://img.shields.io/travis/jekyll/classifier-reborn/master.svg)](https://travis-ci.org/jekyll/classifier-reborn)
 ---
 
-## [Read the Docs](https://www.classifier-reborn.com/)
+## [Read the Docs](https://jekyll.github.io/classifier-reborn/)
 
 ## Getting Started
 
@@ -43,11 +43,11 @@ irb(main):013:0> lsi.find_related("This text is around cats!", 2)
 There is much more that can be done using Bayes and LSI beyond these quick examples.
 For more information read the following documentation topics.
 
-* [Installation and Dependencies](https://www.classifier-reborn.com/)
-* [Bayesian Classifier](https://www.classifier-reborn.com/bayes)
-* [Latent Semantic Indexer (LSI)](https://www.classifier-reborn.com/lsi)
-* [Classifier Validation](https://www.classifier-reborn.com/validation)
-* [Development and Contributions](https://www.classifier-reborn.com/development) (*Optional Docker instructions included*)
+* [Installation and Dependencies](https://jekyll.github.io/classifier-reborn/)
+* [Bayesian Classifier](https://jekyll.github.io/classifier-reborn/bayes)
+* [Latent Semantic Indexer (LSI)](https://jekyll.github.io/classifier-reborn/lsi)
+* [Classifier Validation](https://jekyll.github.io/classifier-reborn/validation)
+* [Development and Contributions](https://jekyll.github.io/classifier-reborn/development) (*Optional Docker instructions included*)
 
 ### Notes on JRuby support
 

--- a/classifier-reborn-jruby.gemspec
+++ b/classifier-reborn-jruby.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.summary          = 'A general classifier module to allow Bayesian and other types of classifications.'
   s.authors          = ['Lucas Carlson', 'Parker Moore', 'Chase Gilliam']
   s.email            = ['lucas@rufy.com', 'parkrmoore@gmail.com', 'chase.gilliam@gmail.com']
-  s.homepage         = 'https://github.com/jekyll/classifier-reborn'
+  s.homepage         = 'https://github.com/jekyll/classifier-reborn/'
 
   all_files          = `git ls-files -z`.split("\x0")
   s.files            = all_files.grep(%r{^(bin|lib|data)/})

--- a/classifier-reborn.gemspec
+++ b/classifier-reborn.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.summary          = 'A general classifier module to allow Bayesian and other types of classifications.'
   s.authors          = ['Lucas Carlson', 'Parker Moore', 'Chase Gilliam']
   s.email            = ['lucas@rufy.com', 'parkrmoore@gmail.com', 'chase.gilliam@gmail.com']
-  s.homepage         = 'http://www.classifier-reborn.com'
+  s.homepage         = 'https://jekyll.github.io/classifier-reborn/'
 
   all_files          = `git ls-files -z`.split("\x0")
   s.files            = all_files.grep(%r{^(bin|lib|data)/})


### PR DESCRIPTION
Now that we are using the default GitHub pages domain, referenced in the README and other pages are changed accordingly. This closes #186.