### PR TITLE
Allow Redis Connection to be Injected

### DIFF
--- a/lib/classifier-reborn/backends/bayes_redis_backend.rb
+++ b/lib/classifier-reborn/backends/bayes_redis_backend.rb
@@ -6,13 +6,16 @@ require_relative 'no_redis_error'
 module ClassifierReborn
   # This class provides Redis as the storage backend for the classifier data structures
   class BayesRedisBackend
-    # The class can be created with the same arguments that the redis gem accepts
+    # The class can be given an existing redis connection, or it can create
+    # a new connection for you with the same arguments that the
+    # {redis gem}[https://github.com/redis/redis-rb] accepts
     # E.g.,
     #      b = ClassifierReborn::BayesRedisBackend.new
     #      b = ClassifierReborn::BayesRedisBackend.new host: "10.0.1.1", port: 6380, db: 2
     #      b = ClassifierReborn::BayesRedisBackend.new url: "redis://:secret@10.0.1.1:6380/2"
     #
     # Options available are:
+    #   redis_conn:         an existing redis connection
     #   url:                lambda { ENV["REDIS_URL"] }
     #   scheme:             "redis"
     #   host:               "127.0.0.1"
@@ -33,7 +36,7 @@ module ClassifierReborn
         raise NoRedisError
       end
 
-      @redis = Redis.new(options)
+      @redis = options.fetch(:redis_conn, Redis.new(options))
       @redis.setnx(:total_words, 0)
       @redis.setnx(:total_trainings, 0)
     end

--- a/test/backends/backend_redis_injected_test.rb
+++ b/test/backends/backend_redis_injected_test.rb
@@ -1,0 +1,19 @@
+require File.dirname(__FILE__) + '/../test_helper'
+require 'redis'
+require_relative './backend_common_tests'
+
+class BackendRedisInjectedTest < Minitest::Test
+  include BackendCommonTests
+
+  def setup
+    redis = Redis.new
+    @backend = ClassifierReborn::BayesRedisBackend.new(redis_conn: redis)
+    redis.config(:set, 'save', '')
+  rescue Redis::CannotConnectError => e
+    skip(e)
+  end
+
+  def teardown
+    @backend.reset if defined? @backend
+  end
+end


### PR DESCRIPTION
See issue #188 for details.

Prior to this change, pooled redis connections were hard to share across jobs.

Now you can inject your own redis connection into the intiailizer via
the `redis_conn` parameter.