### PR TITLE
Updated Bayes docs for filters

### DIFF
--- a/docs/bayes.md
+++ b/docs/bayes.md
@@ -201,7 +201,7 @@ filters = [
   white_filter
   # If you want to reject stopwords too, you need to include stopword filter
   # to the list of token filters manually.
-  ClassifierReborn::TokenFilters::Stopword,
+  ClassifierReborn::TokenFilter::Stopword,
 ]
 classifier = ClassifierReborn::Bayes.new token_filters: filters
 ```


### PR DESCRIPTION
Fixed typo in Bayes documentation where `TokenFilter` was documented as `TokenFilters`

![image](https://user-images.githubusercontent.com/3459902/84730781-ca0e2c80-af5c-11ea-9c18-243effa39965.png)
