### PR TITLE
Test Native and GSL Implementations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   ci:
-    name: "Run Tests (${{ matrix.label }})"
+    name: "Run Tests (Ruby ${{ matrix.ruby_version }}, GSL: ${{ matrix.gsl }})"
     runs-on: "ubuntu-latest"
     env:
       # See https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby#matrix-of-gemfiles
@@ -22,19 +22,30 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        ruby_version: ["2.7", "3.0", "3.1", "jruby-9.3.4.0"]
+        gsl: [true, false]
+        # We use `include` to assign the correct Gemfile for each ruby_version
         include:
-          - label: Ruby 2.7
-            ruby_version: "2.7"
+          - ruby_version: "2.7"
             gemfile: Gemfile
-          - label: Ruby 3.0
-            ruby_version: "3.0"
+          - ruby_version: "3.0"
             gemfile: Gemfile
-          - label: Ruby 3.1
-            ruby_version: "3.1"
+          - ruby_version: "3.1"
             gemfile: Gemfile
-          - label: JRuby 9.3.4.0
-            ruby_version: "jruby-9.3.4.0"
+          - ruby_version: "jruby-9.3.4.0"
             gemfile: Gemfile-jruby
+        exclude:
+          # Ruby 3.0 does not work with the latest released gsl gem
+          # https://github.com/SciRuby/rb-gsl/issues/67
+          - ruby_version: "3.0"
+            gsl: true
+          # Ruby 3.1 does not work with the latest released gsl gem
+          # https://github.com/SciRuby/rb-gsl/issues/67
+          - ruby_version: "3.1"
+            gsl: true
+          # jruby-9.3.4.0 doesn't easily build the gsl gem on a GitHub worker. Skipping for now.
+          - ruby_version: "jruby-9.3.4.0"
+            gsl: true
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
@@ -43,8 +54,12 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby_version }}
           bundler-cache: true
+      - name: Install GSL Gem
+        if: ${{ matrix.gsl }}
+        run: gem install gsl
       - name: Run Minitest based tests
         run: script/test
+
     services:
       redis:
         image: redis

--- a/test/lsi/lsi_test.rb
+++ b/test/lsi/lsi_test.rb
@@ -163,7 +163,7 @@ class LSITest < Minitest::Test
   end
 
   def test_clears_cached_content_node_cache
-    return unless $GSL
+    skip "transposed_search_vector is only used by GSL implementation" unless $GSL
 
     lsi = ClassifierReborn::LSI.new(cache_node_vectors: true)
     lsi.add_item @str1, 'Dog'
@@ -192,7 +192,7 @@ class LSITest < Minitest::Test
   end
 
   def test_invalid_searching_when_using_gsl
-    return unless $GSL
+    skip "Only GSL currently raises invalid search error" unless $GSL
 
     lsi = ClassifierReborn::LSI.new
     lsi.add_item @str1, 'Dog'


### PR DESCRIPTION
classifier-reborn is designed to work with or without
[GSL](https://www.gnu.org/software/gsl/) support.

https://github.com/jekyll/classifier-reborn/blob/99d13af5adf040ba40a6fe77dbe0b28756562fcc/docs/index.md?plain=1#L68

If GSL is installed, classifier-reborn will detect it and use it. If GSL
is not installed, classifier-reborn will fall back to a pure-ruby
implementation. The mechanism for doing so is in `lsi.rb`:

https://github.com/jekyll/classifier-reborn/blob/99d13af5adf040ba40a6fe77dbe0b28756562fcc/lib/classifier-reborn/lsi.rb#L7-L17

I think it's important to test the classifier-reborn gem with GSL
support in CI. One of my goals is to add similar support using Numo,
and I'd like that to be tested in CI as well. Also, I want to make sure I
don't do anything along the way that could break existing GSL support.
As far as I can tell, GSL support was never tested in CI before now
(though it was previously discussed
[here](https://github.com/jekyll/classifier-reborn/pull/46#issuecomment-140099464)).

In this PR, I'm expanding our text matrix to test with and without GSL
enabled. When the matrix has GSL enabled, we install the `gsl` gem
(which is not included in our Gemfile since it's optional). Lucky for
us, GitHub already [includes libgsl as pre-installed
software](https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md#installed-apt-packages),
so we don't need to do anything special for the apt package. Our gem
already has everything needed to build & install. When `matrix.gsl` is
false, we won't install the gem and tests will run the native Ruby
implementation. When `matrix.gsl` is true, we'll install the gem tests
will run the GSL implementation.

Currently, GSL only works with Ruby 2.7. (One of the main reasons I want
to add support for Numo is because GSL is becoming difficult to
support.) As such, I've excluded other versions of ruby in our test
matrix for now. They'll still be tested with GSL disabled, but not with
it enabled.

While working on this, I noticed some tests in the LSI spec that return
early when `$GSL` is not enabled. It would be better for those tests to
report as skipped when GSL is not enabled (and this matches the pattern
of the redis tests, that report as skipped if redis isn't available).