### PR TITLE
Actually Use GSL in CI Tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
     env:
       # See https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby#matrix-of-gemfiles
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
+      LOAD_GSL: ${{ matrix.gsl }}
     strategy:
       fail-fast: false
       matrix:
@@ -54,9 +55,6 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby_version }}
           bundler-cache: true
-      - name: Install GSL Gem
-        if: ${{ matrix.gsl }}
-        run: gem install gsl
       - name: Run Minitest based tests
         run: script/test
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,6 @@
 
 source 'https://rubygems.org'
 gemspec name: 'classifier-reborn'
+
+# For testing with GSL support & bundle exec
+gem 'gsl' if ENV['LOAD_GSL'] == 'true'

--- a/test/extensions/matrix_test.rb
+++ b/test/extensions/matrix_test.rb
@@ -2,6 +2,8 @@
 
 class MatrixTest < Minitest::Test
   def test_zero_division
+    skip "extensions/vector is only used by non-GSL implementation" if $GSL
+    
     matrix = Matrix[[1, 0], [0, 1]]
     matrix.SV_decomp
   end

--- a/test/extensions/zero_vector_test.rb
+++ b/test/extensions/zero_vector_test.rb
@@ -2,6 +2,8 @@
 
 class ZeroVectorTest < Minitest::Test
   def test_zero?
+    skip "extensions/zero_vector is only used by non-GSL implementation" if $GSL
+
     vec0 = Vector[]
     vec1 = Vector[0]
     vec10 = Vector.elements [0] * 10


### PR DESCRIPTION
In #196, I attempted to make the CI tests execute both with and without
GSL support because classifier-reborn is supposed to work in both cases
(though GSL increases performance). However, while doing so, I missed
the fact that `script/test` (which our CI job runs) uses `bundle exec`
to run the tests. And when the tests are run with `bundle exec`, Bundler
will not load gems that aren't specified in the Gemfile. So our GSL
tests weren't actually using the GSL gem.

To fix this, we add `gem 'gsl' if ENV["LOAD_GSL"]` to our Gemfile. (This
solution was proposed by ashmaroli.) This won't do anything in most
cases (when `LOAD_GSL` isn't set). But when we set it (in our CI env),
it will include GSL in our bundled gems so that we can actually test
with GSL support in CI.

See here for more info:
https://github.com/jekyll/classifier-reborn/pull/196#issuecomment-1126659221