### PR TITLE
Update macOS instructions in Numo docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -70,12 +70,13 @@ Note that LSI will work without these libraries, but as soon as they are install
 
 * Install [LAPACKE](https://www.netlib.org/lapack/lapacke.html)
   * Ubuntu: `apt-get install liblapacke-dev`
-  * macOS: (Help wanted to verify installation steps) https://stackoverflow.com/questions/38114201/installing-lapack-and-blas-libraries-for-c-on-mac-os
+  * macOS: `brew install lapack`
 * Install [OpenBLAS](https://www.openblas.net/)
   * Ubuntu: `apt-get install libopenblas-dev`
-  * macOS: (Help wanted to verify installation steps) https://stackoverflow.com/questions/38114201/installing-lapack-and-blas-libraries-for-c-on-mac-os
-* Install the [Numo::NArray](https://ruby-numo.github.io/narray/) and [Numo::Linalg](https://ruby-numo.github.io/linalg/) gems
-  * `gem install numo-narray numo-linalg`
+  * macOS: `brew install openblas`
+* Install the [Numo::NArray](https://ruby-numo.github.io/narray/) and [Numo::Linalg](https://ruby-numo.github.io/linalg/) gems. If you're using Bundler, add `numo-narray` and `numo-linalg` to your Gemfile.
+  * Ubuntu: `gem install numo-narray numo-linalg`
+  * macOS: `gem install numo-narray`, `gem install numo-linalg -- --with-openblas-dir=/opt/homebrew/opt/openblas --with-lapack-lib=/opt/homebrew/opt/lapack/lib`
 
 ### Install GSL Gem
 
@@ -85,7 +86,7 @@ The [GNU Scientific Library (GSL)](http://www.gnu.org/software/gsl) is an altern
 
 * Install the [GNU Scientific Library](http://www.gnu.org/software/gsl)
   * Ubuntu: `apt-get install libgsl-dev`
-* Install the [Ruby/GSL Gem](https://rubygems.org/gems/gsl) (or add it to your Gemfile)
+* Install the [Ruby/GSL Gem](https://rubygems.org/gems/gsl). If you're using Bundler, add `gsl` to your Gemfile.
   * `gem install gsl`
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -76,7 +76,7 @@ Note that LSI will work without these libraries, but as soon as they are install
   * macOS: `brew install openblas`
 * Install the [Numo::NArray](https://ruby-numo.github.io/narray/) and [Numo::Linalg](https://ruby-numo.github.io/linalg/) gems. If you're using Bundler, add `numo-narray` and `numo-linalg` to your Gemfile.
   * Ubuntu: `gem install numo-narray numo-linalg`
-  * macOS: `gem install numo-narray`, `gem install numo-linalg -- --with-openblas-dir=/opt/homebrew/opt/openblas --with-lapack-lib=/opt/homebrew/opt/lapack/lib`
+  * macOS: `gem install numo-narray`, `gem install numo-linalg -- --with-openblas-dir=$(brew --prefix openblas) --with-lapack-lib="$(brew --prefix lapack)/lib"
 
 ### Install GSL Gem
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -74,7 +74,7 @@ Note that LSI will work without these libraries, but as soon as they are install
 * Install [OpenBLAS](https://www.openblas.net/)
   * Ubuntu: `apt-get install libopenblas-dev`
   * macOS: `brew install openblas`
-* Install the [Numo::NArray](https://ruby-numo.github.io/narray/) and [Numo::Linalg](https://ruby-numo.github.io/linalg/) gems. If you're using Bundler, add `numo-narray` and `numo-linalg` to your Gemfile.
+* Install the [Numo::NArray](https://ruby-numo.github.io/narray/) and [Numo::Linalg](https://ruby-numo.github.io/linalg/) gems. If you're using Bundler, add `numo-narray` and `numo-linalg` to your Gemfile. (If using Bundler on macOS, you should set the build config like `bundle config set --global build.numo-linalg --with-openblas-dir=$(brew --prefix openblas) --with-lapack-lib="$(brew --prefix lapack)/lib"`.)
   * Ubuntu: `gem install numo-narray numo-linalg`
   * macOS: `gem install numo-narray`, `gem install numo-linalg -- --with-openblas-dir=$(brew --prefix openblas) --with-lapack-lib="$(brew --prefix lapack)/lib"
 


### PR DESCRIPTION
In #198, I added support for using
[Numo::Linalg](https://github.com/ruby-numo/numo-linalg) as the linear
algebra backend for classifier-reborn. At that time, I updated the docs
with instructions for installing Numo, but the macOS docs were a little
vague because I hadn't tested them myself. Since then, I've been able to
verify the instructions on macOS and clarify a few steps. So this commit
updates the docs for installing Numo on macOS. The gem installation
arguments I'm using come from the [Numo
docs](https://github.com/ruby-numo/numo-linalg/blob/master/doc/select-backend.md).