### PR TITLE
Update Dockerfile for Ruby 3.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
-FROM ruby:2.4
-MAINTAINER Sawood Alam <https://github.com/ibnesayeed>
+FROM ruby:3.1
 
 ENV LANG C.UTF-8
 
-RUN apt update && apt install -y libgsl0-dev && rm -rf /var/lib/apt/lists/*
-RUN gem install narray nmatrix gsl jekyll github-pages
+RUN apt update && apt install -y liblapacke-dev libopenblas-dev && rm -rf /var/lib/apt/lists/*
+RUN gem install numo-narray numo-linalg jekyll github-pages
 
 RUN cd /tmp \
     && wget http://download.redis.io/redis-stable.tar.gz \


### PR DESCRIPTION
While working on Ruby 3 support several months ago, I noticed the [Dockerfile](https://github.com/jekyll/classifier-reborn/blob/c3e5a84c3e0915d20ab52f2b783703575584d4a2/Dockerfile) was really stale. I didn't immediately fix this at the time, but made a mental note to come back to it sometime.

This Dockerfile is intended to be used for development. It was added in https://github.com/jekyll/classifier-reborn/pull/104 (discussed in detail at https://github.com/jekyll/classifier-reborn/issues/101). The documentation for using this is still available (and accurate) at https://jekyll.github.io/classifier-reborn/development#development-using-docker.

classifier-reborn currently supports ruby 2.7, 3.0, and 3.1 (as you can see in `ci.yml`). Since we can only (easily) put one ruby version in the Dockerfile, using the most recent version made sense to me. Doing so means we have to use Numo instead of GSL since GSL isn't currently supported on Ruby 3.x.

The `MAINTAINER` dockerfile instruction is deprecated, so I removed it. (It isn't necessary anyway on a Dockerfile that doesn't publish a build.)