### PR TITLE
Constrain redis to < 5.0

### DIFF
--- a/classifier-reborn.gemspec
+++ b/classifier-reborn.gemspec
@@ -34,6 +34,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency('pry')
   s.add_development_dependency('rake')
   s.add_development_dependency('rdoc')
-  s.add_development_dependency('redis')
+  s.add_development_dependency('redis', '< 5.0')
   s.add_development_dependency('rubocop')
 end


### PR DESCRIPTION
CI has been failing on recent PRs. However, CI passed at the time changes were merged to master. I dug into this problem and found that version 5.x of the redis gem causes CI to fail. Constraining our dependency on the redis gem to `< 5.0` makes CI pass. It seems reasonable to me to merge this restriction, at least for now, since the code that's currently in master clearly doesn't work with redis >= 5.x.