### PR TITLE
Redis#sadd will always return an Integer in Redis 5.0.0. Use Redis#sa…

### DIFF
--- a/lib/classifier-reborn/backends/bayes_redis_backend.rb
+++ b/lib/classifier-reborn/backends/bayes_redis_backend.rb
@@ -77,7 +77,7 @@ module ClassifierReborn
     end
 
     def add_category(category)
-      @redis.sadd(:category_keys, category)
+      @redis.sadd?(:category_keys, category)
     end
 
     def category_keys


### PR DESCRIPTION
Redis#sadd will always return an Integer in Redis 5.0.0. Use Redis#sadd? instead.