### PR TITLE
improve numerical stability of vector.rb

### DIFF
--- a/lib/classifier-reborn/extensions/vector.rb
+++ b/lib/classifier-reborn/extensions/vector.rb
@@ -61,7 +61,7 @@ class Matrix
     end # of do while true
     s = []
     qrot.row_size.times do |r|
-      s << Math.sqrt(qrot[r, r])
+      s << Math.sqrt(qrot[r, r] + 1e-7)
     end
     # puts "cnt = #{cnt}"
     if row_size >= column_size


### PR DESCRIPTION
when `qrot[r, r]` is close to 0, ruby might represent it with a small negative value (e.g., `-2.8475347e-16`), which results in error when passed to `Math.sqrt`. adding a small epsilon constant to `qrot[r, r]` inside `Math.sqrt` solves the issue.